### PR TITLE
Minor fix for when attributes is not defined.

### DIFF
--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -106,26 +106,26 @@ function BodyReader(options) {
             }
             var alignElement = element.first("w:jc");
             if (alignElement) {
-                properties.alignment = alignElement.attributes["w:val"];
+               properties.alignment = alignElement.attributes["w:val"];
             }
             var numberingPropertiesElement = element.first("w:numPr");
             if (numberingPropertiesElement) {
-                var levelElement = numberingPropertiesElement.first("w:ilvl");
-					 var level = 0;
-					 if ((typeof levelElement !== "undefined" && levelElement !== null ? levelElement.attributes : void 0) != null) {
-						   level = levelElement.attributes["w:val"];
-					 }
-                // var level = levelElement.attributes["w:val"] : 0;
-                var numId = 0; // numberingPropertiesElement.first("w:numId").attributes["w:val"];
-					 var ref;
+               var levelElement = numberingPropertiesElement.first("w:ilvl");
+               var level = 0;
+               if ((typeof levelElement !== "undefined" && levelElement !== null ? levelElement.attributes : void 0) != null) {
+                  level = levelElement.attributes["w:val"];
+               }
+               // var level = levelElement.attributes["w:val"] : 0;
+               var numId = 0; // numberingPropertiesElement.first("w:numId").attributes["w:val"];
+               var ref;
 
-					 if (((ref = numberingPropertiesElement.first("w:numId")) != null ? ref.attributes : void 0) != null) {
-						   numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
-					 }
+               if (((ref = numberingPropertiesElement.first("w:numId")) != null ? ref.attributes : void 0) != null) {
+                  numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
+               }
 
-                properties.numbering = numbering.findLevel(numId, level);
+               properties.numbering = numbering.findLevel(numId, level);
             }
-            
+
             return elementResult(properties);
         },
         "w:r": function(element) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -111,8 +111,18 @@ function BodyReader(options) {
             var numberingPropertiesElement = element.first("w:numPr");
             if (numberingPropertiesElement) {
                 var levelElement = numberingPropertiesElement.first("w:ilvl");
-                var level = levelElement.attributes["w:val"];
-                var numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
+					 var level = 0;
+					 if ((typeof levelElement !== "undefined" && levelElement !== null ? levelElement.attributes : void 0) != null) {
+						   level = levelElement.attributes["w:val"];
+					 }
+                // var level = levelElement.attributes["w:val"] : 0;
+                var numId = 0; // numberingPropertiesElement.first("w:numId").attributes["w:val"];
+					 var ref;
+
+					 if (((ref = numberingPropertiesElement.first("w:numId")) != null ? ref.attributes : void 0) != null) {
+						   numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
+					 }
+
                 properties.numbering = numbering.findLevel(numId, level);
             }
             

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -94,7 +94,7 @@ function BodyReader(options) {
             var properties = {
                 type: "paragraphProperties"
             };
-            
+
             var styleElement = element.first("w:pStyle");
             if (styleElement) {
                 var styleId = styleElement.attributes["w:val"];
@@ -106,24 +106,20 @@ function BodyReader(options) {
             }
             var alignElement = element.first("w:jc");
             if (alignElement) {
-               properties.alignment = alignElement.attributes["w:val"];
+                properties.alignment = alignElement.attributes["w:val"];
             }
             var numberingPropertiesElement = element.first("w:numPr");
             if (numberingPropertiesElement) {
-               var levelElement = numberingPropertiesElement.first("w:ilvl");
-               var level = 0;
-               if ((typeof levelElement !== "undefined" && levelElement !== null ? levelElement.attributes : void 0) != null) {
-                  level = levelElement.attributes["w:val"];
-               }
-               // var level = levelElement.attributes["w:val"] : 0;
-               var numId = 0; // numberingPropertiesElement.first("w:numId").attributes["w:val"];
-               var ref;
+                var levelElement = numberingPropertiesElement.first("w:ilvl");
+                var level = 0, numId = 0, ref;
+                if ((typeof levelElement !== "undefined" && levelElement !== null ? levelElement.attributes : void 0) != null) {
+                    level = levelElement.attributes["w:val"];
+                }
+                if (((ref = numberingPropertiesElement.first("w:numId")) != null ? ref.attributes : void 0) != null) {
+                    numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
+                }
 
-               if (((ref = numberingPropertiesElement.first("w:numId")) != null ? ref.attributes : void 0) != null) {
-                  numId = numberingPropertiesElement.first("w:numId").attributes["w:val"];
-               }
-
-               properties.numbering = numbering.findLevel(numId, level);
+                properties.numbering = numbering.findLevel(numId, level);
             }
 
             return elementResult(properties);
@@ -349,3 +345,4 @@ function combineResults(results) {
 function joinElements(first, second) {
     return _.flatten([first, second]);
 }
+// vim: set ts=4 sts=0 sw=4 et:


### PR DESCRIPTION
```
/usr/local/lib/node_modules/mammoth/node_modules/bluebird/js/main/async.js:95
                throw res.e;
                         ^
TypeError: Cannot read property 'attributes' of undefined
    at BodyReader.xmlElementReaders.w:pPr (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:114:41)
    at readXmlElement (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:26:24)
    at Array.map (native)
    at readXmlElements (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:18:32)
    at BodyReader.xmlElementReaders.w:p (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:83:20)
    at readXmlElement (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:26:24)
    at Array.map (native)
    at Object.readXmlElements (/usr/local/lib/node_modules/mammoth/lib/docx/body-reader.js:18:32)
    at Object.convertXmlToDocument (/usr/local/lib/node_modules/mammoth/lib/docx/document-xml-reader.js:13:33)
    at /usr/local/lib/node_modules/mammoth/lib/docx/docx-reader.js:59:31
    at Result.flatMap (/usr/local/lib/node_modules/mammoth/lib/results.js:18:22)
```