### PR TITLE
added 'error' messages; exceptions in imgConvert are now errors (not warnings)

### DIFF
--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -185,7 +185,7 @@ function DocumentConversion(options) {
     function recoveringConvertImage(convertImage) {
         return function(image, messages) {
             return convertImage(image, messages).caught(function(error) {
-                messages.push(results.warning(error.message));
+                messages.push(results.error(error));
                 return [];
             });
         };

--- a/lib/results.js
+++ b/lib/results.js
@@ -46,11 +46,18 @@ function warning(message) {
 }
 
 function error(exception) {
-    return {
-        type: "error",
-        message: exception.message,
-        stack: exception.stack
-    };
+    if (typeof exception == 'string') {
+        return {
+            type: "error",
+            message: exception
+        };
+    } else {
+        return {
+            type: "error",
+            message: exception.message,
+            stack: exception.stack
+        };
+    }
 }
 
 function combineMessages(results) {

--- a/lib/results.js
+++ b/lib/results.js
@@ -4,6 +4,7 @@ var _ = require("underscore");
 exports.Result = Result;
 exports.success = success;
 exports.warning = warning;
+exports.error = error;
 
 
 function Result(value, messages) {
@@ -41,6 +42,14 @@ function warning(message) {
     return {
         type: "warning",
         message: message
+    };
+}
+
+function error(exception) {
+    return {
+        type: "error",
+        message: exception.message,
+        stack: exception.stack
     };
 }
 

--- a/lib/results.js
+++ b/lib/results.js
@@ -46,18 +46,11 @@ function warning(message) {
 }
 
 function error(exception) {
-    if (typeof exception == 'string') {
-        return {
-            type: "error",
-            message: exception
-        };
-    } else {
-        return {
-            type: "error",
-            message: exception.message,
-            stack: exception.stack
-        };
-    }
+    return {
+        type: "error",
+        message: exception.message,
+        stack: exception.stack
+    };
 }
 
 function combineMessages(results) {

--- a/test/mammoth.tests.js
+++ b/test/mammoth.tests.js
@@ -192,12 +192,13 @@ describe('mammoth', function() {
         });
     });
     
-    test('warn if images stored outside of document are specified when passing file without path', function() {
+    test('error if images stored outside of document are specified when passing file without path', function() {
         var docxPath = path.join(__dirname, "test-data/external-picture.docx");
         var buffer = fs.readFileSync(docxPath);
         return mammoth.convertToHtml({buffer: buffer}).then(function(result) {
             assert.equal(result.value, '');
-            assert.equal(result.messages[0].message, results.error("could not find external image 'tiny-picture.png', path of input document is unknown").message);
+            assert.equal(result.messages[0].message, "could not find external image 'tiny-picture.png', path of input document is unknown");
+            assert.equal(result.messages[0].type, "error");
         });
     });
     

--- a/test/mammoth.tests.js
+++ b/test/mammoth.tests.js
@@ -197,7 +197,7 @@ describe('mammoth', function() {
         var buffer = fs.readFileSync(docxPath);
         return mammoth.convertToHtml({buffer: buffer}).then(function(result) {
             assert.equal(result.value, '');
-            assert.deepEqual(result.messages, [results.warning("could not find external image 'tiny-picture.png', path of input document is unknown")]);
+            assert.equal(result.messages[0].message, results.error("could not find external image 'tiny-picture.png', path of input document is unknown").message);
         });
     });
     


### PR DESCRIPTION
See this issue: https://github.com/mwilliamson/mammoth.js/issues/86