### PR TITLE
Point `browser` key to actual file that might be used in browser in production

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ npm-install:
 	npm install
 
 mammoth.browser.js:
-	node_modules/.bin/browserify lib/index.js --standalone mammoth --no-browser-field --transform aliasify -p browserify-prepend-licenses > $@
+	node_modules/.bin/browserify lib/index.js --standalone mammoth --transform aliasify -p browserify-prepend-licenses > $@
 
 mammoth.browser.min.js: mammoth.browser.js
 	node_modules/.bin/uglifyjs mammoth.browser.js -c > $@

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ npm-install:
 	npm install
 
 mammoth.browser.js:
-	node_modules/.bin/browserify lib/index.js --standalone mammoth -p browserify-prepend-licenses > $@
+	node_modules/.bin/browserify lib/index.js --standalone mammoth --no-browser-field --transform aliasify -p browserify-prepend-licenses > $@
 
 mammoth.browser.min.js: mammoth.browser.js
 	node_modules/.bin/uglifyjs mammoth.browser.js -c > $@

--- a/package.json
+++ b/package.json
@@ -27,19 +27,23 @@
     "path-is-absolute": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "~2.2.5",
+    "aliasify": "^2.1.0",
     "browserify": "~13.0.1",
     "browserify-prepend-licenses": "~1.0.0",
     "duck": "~0.1.11",
-    "uglify-js": "~2.4.8",
-    "temp": "~0.7.0",
     "eslint": "2.13.1",
+    "flow-bin": "^0.32.0",
     "hamjest": "2.13.0",
-    "flow-bin": "^0.32.0"
+    "mocha": "~2.2.5",
+    "temp": "~0.7.0",
+    "uglify-js": "~2.4.8"
   },
-  "browser": {
-    "./lib/unzip.js": "./browser/unzip.js",
-    "./lib/docx/files.js": "./browser/docx/files.js"
+  "browser": "mammoth.browser.js",
+  "aliasify": {
+    "aliases": {
+      "./unzip": "./browser/unzip.js",
+      "./files": "./browser/docx/files.js"
+    }
   },
   "bin": {
     "mammoth": "bin/mammoth"


### PR DESCRIPTION
`browser` key in packages I'm using targets file that is used for browser environment in production.

Having 2 files is not what I expect from library installed via NPM, especially since there are `mammoth.browser.js` and `mammoth.browser.min.js` files in NPM package already.

Tools I have use this information in order to create aliases for NPM packages in RequireJS config. With suggested change it determinstically generates following configuration of RequireJS package:
```json
{
    "name"     : "mammoth",
    "main"     : "mammoth.browser.min",
    "location" : "\/node_modules\/mammoth"
}
```
(`.min` file is used in production mode if present)

This allows me to just call `require(['mammoth'], ...)` instead of `require(['/node_modules/mammoth/mammoth.browser.js'], ...)`.