### PR TITLE
Enable hyperlinks that are not defined with w:hyperlink

### DIFF
--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -159,7 +159,9 @@ function BodyReader(options) {
         "w:rPr": readRunProperties,
         "w:fldChar": function(element) {
             var type = element.attributes["w:fldCharType"];
-            if (type === "end") {
+            if (type === "begin") {
+                currentInstrText = [];
+            } else if (type === "end") {
                 complexFields.pop();
             } else if (type === "separate") {
                 var href = parseHyperlinkFieldCode(currentInstrText.join(''));
@@ -168,7 +170,6 @@ function BodyReader(options) {
                 } else {
                     complexFields.push(null);
                 }
-                currentInstrText = [];
             }
             return emptyResult();
         },

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -6,6 +6,7 @@ var documents = require("../documents");
 var Result = require("../results").Result;
 var warning = require("../results").warning;
 var uriToZipEntryName = require("./uris").uriToZipEntryName;
+var lastInstrText = null;
 
 
 function BodyReader(options) {
@@ -133,14 +134,27 @@ function BodyReader(options) {
             return readXmlElements(element.children)
                 .map(function(children) {
                     var properties = _.find(children, isRunProperties);
-                    
-                    return new documents.Run(
-                        children.filter(negate(isRunProperties)),
-                        properties
-                    );
+                    var filteredChildren = children.filter(negate(isRunProperties));
+
+                    if (properties && properties.styleName === 'Hyperlink' && lastInstrText) {
+                        return new documents.Hyperlink(filteredChildren, {href: parseHyperlink(lastInstrText)});
+                    }
+
+                    return new documents.Run(filteredChildren, properties);
                 });
         },
         "w:rPr": readRunProperties,
+        "w:fldChar": function(element) {
+            var type = element.attributes["w:fldCharType"];
+            if (type === 'end') {
+                clearState();
+            }
+            return emptyResult();
+        },
+        "w:instrText": function(element) {
+            lastInstrText = (element.children[0] || {}).value || '';
+            return emptyResult();
+        },
         "w:t": function(element) {
             return elementResult(new documents.Text(element.text()));
         },
@@ -490,4 +504,12 @@ function joinElements(first, second) {
 
 function identity(value) {
     return value;
+}
+
+function clearState() {
+    lastInstrText = null;
+}
+
+function parseHyperlink(instrText) {
+    return (instrText.match(/HYPERLINK "(.*)"/) || [])[1];
 }

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -9,7 +9,7 @@ var uriToZipEntryName = require("./uris").uriToZipEntryName;
 
 
 function BodyReader(options) {
-    var complexFieldData = [];
+    var fieldHyperlink = null;
     var relationships = options.relationships;
     var contentTypes = options.contentTypes;
     var docxFile = options.docxFile;
@@ -134,28 +134,28 @@ function BodyReader(options) {
             return readXmlElements(element.children)
                 .map(function(children) {
                     var properties = _.find(children, isRunProperties);
-                    var filteredChildren = children.filter(negate(isRunProperties));
+                    children = children.filter(negate(isRunProperties));
 
-                    if (properties && properties.styleId === 'Hyperlink' && complexFieldData.length === 1) {
-                        return new documents.Run(
-                            [new documents.Hyperlink(filteredChildren, {href: parseHyperlinkFieldCode(complexFieldData)})],
-                            properties
-                        );
+                    if (fieldHyperlink !== null) {
+                        children = [new documents.Hyperlink(children, {href: fieldHyperlink})];
                     }
 
-                    return new documents.Run(filteredChildren, properties);
+                    return new documents.Run(children, properties);
                 });
         },
         "w:rPr": readRunProperties,
         "w:fldChar": function(element) {
             var type = element.attributes["w:fldCharType"];
-            if (type === 'end') {
-                complexFieldData = [];
+            if (type === "end") {
+                fieldHyperlink = null;
             }
             return emptyResult();
         },
         "w:instrText": function(element) {
-            complexFieldData.push(element.children[0].value);
+            var hyperlink = parseHyperlinkFieldCode(element.text());
+            if (hyperlink !== null) {
+                fieldHyperlink = hyperlink;
+            }
             return emptyResult();
         },
         "w:t": function(element) {
@@ -509,6 +509,11 @@ function identity(value) {
     return value;
 }
 
-function parseHyperlinkFieldCode(complexFieldData) {
-    return (complexFieldData[0].match(/HYPERLINK "(.*)"/) || [])[1];
+function parseHyperlinkFieldCode(code) {
+    var result = /HYPERLINK "(.*)"/.exec(code);
+    if (result) {
+        return result[1];
+    } else {
+        return null;
+    }
 }

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -1,4 +1,5 @@
-exports.BodyReader = BodyReader;
+exports.createBodyReader = createBodyReader;
+exports._readNumberingProperties = readNumberingProperties;
 
 var _ = require("underscore");
 
@@ -7,6 +8,16 @@ var Result = require("../results").Result;
 var warning = require("../results").warning;
 var uriToZipEntryName = require("./uris").uriToZipEntryName;
 
+function createBodyReader(options) {
+    return {
+        readXmlElement: function(element) {
+            return new BodyReader(options).readXmlElement(element);
+        },
+        readXmlElements: function(elements) {
+            return new BodyReader(options).readXmlElements(elements);
+        }
+    };
+}
 
 function BodyReader(options) {
     var fieldHyperlink = null;
@@ -126,7 +137,7 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"))
+                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
             });
         },
@@ -227,21 +238,12 @@ function BodyReader(options) {
         "wp:anchor": readDrawingElement,
         "v:imagedata": readImageData
     };
+    
     return {
         readXmlElement: readXmlElement,
-        readXmlElements: readXmlElements,
-        _readNumberingProperties: readNumberingProperties
+        readXmlElements: readXmlElements
     };
 
-    function readNumberingProperties(element) {
-        var level = element.firstOrEmpty("w:ilvl").attributes["w:val"];
-        var numId = element.firstOrEmpty("w:numId").attributes["w:val"];
-        if (level === undefined || numId === undefined) {
-            return null;
-        } else {
-            return numbering.findLevel(numId, level);
-        }
-    }
     
     function readTable(element) {
         return readXmlElements(element.children)
@@ -394,6 +396,17 @@ function BodyReader(options) {
     function undefinedStyleWarning(type, styleId) {
         return warning(
             type + " style with ID " + styleId + " was referenced but not defined in the document");
+    }
+}
+
+
+function readNumberingProperties(element, numbering) {
+    var level = element.firstOrEmpty("w:ilvl").attributes["w:val"];
+    var numId = element.firstOrEmpty("w:numId").attributes["w:val"];
+    if (level === undefined || numId === undefined) {
+        return null;
+    } else {
+        return numbering.findLevel(numId, level);
     }
 }
     

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -510,7 +510,7 @@ function identity(value) {
 }
 
 function parseHyperlinkFieldCode(code) {
-    var result = /HYPERLINK "(.*)"/.exec(code);
+    var result = /\s*HYPERLINK "(.*)"/.exec(code);
     if (result) {
         return result[1];
     } else {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -6,10 +6,10 @@ var documents = require("../documents");
 var Result = require("../results").Result;
 var warning = require("../results").warning;
 var uriToZipEntryName = require("./uris").uriToZipEntryName;
-var lastInstrText = null;
 
 
 function BodyReader(options) {
+    var complexFieldData = [];
     var relationships = options.relationships;
     var contentTypes = options.contentTypes;
     var docxFile = options.docxFile;
@@ -136,8 +136,11 @@ function BodyReader(options) {
                     var properties = _.find(children, isRunProperties);
                     var filteredChildren = children.filter(negate(isRunProperties));
 
-                    if (properties && properties.styleName === 'Hyperlink' && lastInstrText) {
-                        return new documents.Hyperlink(filteredChildren, {href: parseHyperlink(lastInstrText)});
+                    if (properties && properties.styleId === 'Hyperlink' && complexFieldData.length === 1) {
+                        return new documents.Run(
+                            [new documents.Hyperlink(filteredChildren, {href: parseHyperlinkFieldCode(complexFieldData)})],
+                            properties
+                        );
                     }
 
                     return new documents.Run(filteredChildren, properties);
@@ -147,12 +150,12 @@ function BodyReader(options) {
         "w:fldChar": function(element) {
             var type = element.attributes["w:fldCharType"];
             if (type === 'end') {
-                clearState();
+                complexFieldData = [];
             }
             return emptyResult();
         },
         "w:instrText": function(element) {
-            lastInstrText = (element.children[0] || {}).value || '';
+            complexFieldData.push(element.children[0].value);
             return emptyResult();
         },
         "w:t": function(element) {
@@ -506,10 +509,6 @@ function identity(value) {
     return value;
 }
 
-function clearState() {
-    lastInstrText = null;
-}
-
-function parseHyperlink(instrText) {
-    return (instrText.match(/HYPERLINK "(.*)"/) || [])[1];
+function parseHyperlinkFieldCode(complexFieldData) {
+    return (complexFieldData[0].match(/HYPERLINK "(.*)"/) || [])[1];
 }

--- a/lib/docx/docx-reader.js
+++ b/lib/docx/docx-reader.js
@@ -7,7 +7,7 @@ var documents = require("../documents");
 var Result = require("../results").Result;
 
 var readXmlFromZipFile = require("./office-xml-reader").readXmlFromZipFile;
-var BodyReader = require("./body-reader").BodyReader;
+var createBodyReader = require("./body-reader").createBodyReader;
 var DocumentXmlReader = require("./document-xml-reader").DocumentXmlReader;
 var relationshipsReader = require("./relationships-reader");
 var contentTypesReader = require("./content-types-reader");
@@ -95,7 +95,7 @@ function readXmlFileWithBody(name, options, func) {
     });
     
     return readRelationshipsFromZipFile(options.docxFile).then(function(relationships) {
-        var bodyReader = new BodyReader({
+        var bodyReader = new createBodyReader({
             relationships: relationships,
             contentTypes: options.contentTypes,
             docxFile: options.docxFile,

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -17,7 +17,8 @@ var isHyperlink = documentMatchers.isHyperlink;
 var isRun = documentMatchers.isRun;
 var isText = documentMatchers.isText;
 
-var BodyReader = require("../../lib/docx/body-reader").BodyReader;
+var createBodyReader = require("../../lib/docx/body-reader").createBodyReader;
+var _readNumberingProperties = require("../../lib/docx/body-reader")._readNumberingProperties;
 var documents = require("../../lib/documents");
 var xml = require("../../lib/xml");
 var XmlElement = xml.Element;
@@ -32,7 +33,7 @@ var createFakeDocxFile = testing.createFakeDocxFile;
 function readXmlElement(element, options) {
     options = Object.create(options || {});
     options.styles = options.styles || new Styles({}, {});
-    return new BodyReader(options).readXmlElement(element);
+    return createBodyReader(options).readXmlElement(element);
 }
 
 function readXmlElementValue(element, options) {
@@ -113,10 +114,7 @@ test("numbering properties are converted to numbering at specified level", funct
     
     var numbering = new Numbering({"42": {"1": {isOrdered: true, level: "1"}}});
     
-    var reader = new BodyReader({
-        numbering: numbering
-    });
-    var numberingLevel = reader._readNumberingProperties(numberingPropertiesXml);
+    var numberingLevel = _readNumberingProperties(numberingPropertiesXml, numbering);
     assert.deepEqual(numberingLevel, {level: "1", isOrdered: true});
 });
 
@@ -127,10 +125,7 @@ test("numbering properties are ignored if w:ilvl is missing", function() {
     
     var numbering = new Numbering({"42": {"1": {isOrdered: true, level: "1"}}});
     
-    var reader = new BodyReader({
-        numbering: numbering
-    });
-    var numberingLevel = reader._readNumberingProperties(numberingPropertiesXml);
+    var numberingLevel = _readNumberingProperties(numberingPropertiesXml, numbering);
     assert.equal(numberingLevel, null);
 });
 
@@ -141,10 +136,7 @@ test("numbering properties are ignored if w:numId is missing", function() {
     
     var numbering = new Numbering({"42": {"1": {isOrdered: true, level: "1"}}});
     
-    var reader = new BodyReader({
-        numbering: numbering
-    });
-    var numberingLevel = reader._readNumberingProperties(numberingPropertiesXml);
+    var numberingLevel = _readNumberingProperties(numberingPropertiesXml, numbering);
     assert.equal(numberingLevel, null);
 });
 

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -169,13 +169,13 @@ test("complex fields", (function() {
         "runs in a complex field for hyperlinks are read as hyperlinks": function() {
             var hyperlinkRunXml = runOfText("this is a hyperlink");
             var afterEndXml = runOfText("this will not be a hyperlink");
-            var parXml = new XmlElement("w:p", {}, [
+            var paragraphXml = new XmlElement("w:p", {}, [
                 beginXml,
                 hyperlinkInstrText,
                 hyperlinkRunXml,
                 endXml
             ]);
-            var paragraph = readXmlElementValue(parXml);
+            var paragraph = readXmlElementValue(paragraphXml);
             
             assertThat(paragraph.children, contains(
                 isEmptyRun,
@@ -195,13 +195,13 @@ test("complex fields", (function() {
         
         "runs after a complex field for hyperlinks are not read as hyperlinks": function() {
             var afterEndXml = runOfText("this will not be a hyperlink");
-            var parXml = new XmlElement("w:p", {}, [
+            var paragraphXml = new XmlElement("w:p", {}, [
                 beginXml,
                 hyperlinkInstrText,
                 endXml,
                 afterEndXml
             ]);
-            var paragraph = readXmlElementValue(parXml);
+            var paragraph = readXmlElementValue(paragraphXml);
             
             assertThat(paragraph.children, contains(
                 isEmptyRun,

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -173,8 +173,7 @@ test("complex fields", (function() {
                 beginXml,
                 hyperlinkInstrText,
                 hyperlinkRunXml,
-                endXml,
-                afterEndXml
+                endXml
             ]);
             var paragraph = readXmlElementValue(parXml);
             
@@ -190,9 +189,24 @@ test("complex fields", (function() {
                         })
                     )
                 }),
+                isEmptyRun
+            ));
+        },
+        
+        "runs after a complex field for hyperlinks are not read as hyperlinks": function() {
+            var afterEndXml = runOfText("this will not be a hyperlink");
+            var parXml = new XmlElement("w:p", {}, [
+                beginXml,
+                hyperlinkInstrText,
+                endXml,
+                afterEndXml
+            ]);
+            var paragraph = readXmlElementValue(parXml);
+            
+            assertThat(paragraph.children, contains(
+                isEmptyRun,
                 isEmptyRun,
                 isRun({
-                    // runs after fldCharType "end" do not become hyperlinks
                     children: contains(
                         isText("this will not be a hyperlink")
                     )

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -147,7 +147,7 @@ test("stores instrText returns empty result", function() {
     assert.deepEqual(instrText, []);
 });
 
-test("run is wrapped in a hyperlink if the runStyle is Hyperlink", function() {
+test("runs in a complex field for hyperlinks are read as hyperlinks", function() {
     var uri = "http://example.com";
     var beginXml = new XmlElement("w:r", {}, [
         new XmlElement("w:fldChar", {"w:fldCharType": "begin"})
@@ -156,8 +156,8 @@ test("run is wrapped in a hyperlink if the runStyle is Hyperlink", function() {
         new XmlElement("w:fldChar", {"w:fldCharType": "end"})
     ]);
     var instrTextXml = new XmlElement("w:instrText", {}, [xml.text(' HYPERLINK "' + uri + '"')]);
-    var hyperlinkRunXml = createHyperlinkRunXml('this is a hyperlink');
-    var afterEndXml = createHyperlinkRunXml('this will not be a hyperlink');
+    var hyperlinkRunXml = runOfText("this is a hyperlink");
+    var afterEndXml = runOfText("this will not be a hyperlink");
     var parXml = new XmlElement("w:p", {}, [
         beginXml,
         instrTextXml,
@@ -165,8 +165,7 @@ test("run is wrapped in a hyperlink if the runStyle is Hyperlink", function() {
         endXml,
         afterEndXml
     ]);
-    var styles = new Styles({}, {"Hyperlink": {name: "Hyperlink"}});
-    var paragraph = readXmlElementValue(parXml, {styles: styles});
+    var paragraph = readXmlElementValue(parXml);
 
     var hyperlinkRun = paragraph.children[1];
     var hyperlink = hyperlinkRun.children[0];
@@ -903,10 +902,9 @@ function createLinkedBlip(relationshipId) {
     return new XmlElement("a:blip", {"r:link": relationshipId});
 }
 
-function createHyperlinkRunXml(text) {
-    var styleXml = new XmlElement("w:rStyle", {"w:val": "Hyperlink"});
+function runOfText(text) {
     var textXml = new XmlElement("w:t", {}, [xml.text(text)]);
-    return new XmlElement("w:r", {}, [createRunPropertiesXml([styleXml]), textXml]);
+    return new XmlElement("w:r", {}, [textXml]);
 }
 
 function assertImageBuffer(element, expectedImageBuffer) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -141,6 +141,18 @@ test("numbering properties are ignored if w:numId is missing", function() {
     assert.equal(numberingLevel, null);
 });
 
+test("stores instrText returns empty result", function() {
+    var instrTextXml = new XmlElement("w:instrText", {}, [xml.text(' HYPERLINK "http://example.com"')]);
+    var instrText = readXmlElementValue(instrTextXml);
+    assert.deepEqual(instrText, []);
+});
+
+test("run is wrapped in a hyperlink if the runStyle is Hyperlink", function() {
+    var hyperlink = createHyperlink("http://example.com");
+    assert.equal(hyperlink.type, 'hyperlink');
+    assert.equal(hyperlink.href, 'http://example.com');
+});
+
 test("run has no style if it has no properties", function() {
     var runXml = runWithProperties([]);
     var run = readXmlElementValue(runXml);
@@ -859,6 +871,23 @@ function createEmbeddedBlip(relationshipId) {
 
 function createLinkedBlip(relationshipId) {
     return new XmlElement("a:blip", {"r:link": relationshipId});
+}
+
+function createHyperlink(link) {
+    var beginXml = new XmlElement("w:r", {}, [
+        new XmlElement("w:fldChar", {"w:fldCharType": "begin"})
+    ]);
+    var endXml = new XmlElement("w:r", {}, [
+        new XmlElement("w:fldChar", {"w:fldCharType": "end"})
+    ]);
+    var instrTextXml = new XmlElement("w:instrText", {}, [xml.text(' HYPERLINK "' + link + '"')]);
+    var instrRunXml = new XmlElement("w:r", {}, [instrTextXml]);
+    var styleXml = new XmlElement("w:rStyle", {"w:val": "Hyperlink"});
+    var runStyleXml = runWithProperties([styleXml]);
+    var parXml = new XmlElement("w:p", {}, [beginXml, instrRunXml, runStyleXml, endXml]);
+    var styles = new Styles({}, {"Hyperlink": {name: "Hyperlink"}});
+    var par = readXmlElementValue(parXml, {styles: styles});
+    return par.children[2];
 }
 
 function assertImageBuffer(element, expectedImageBuffer) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -156,21 +156,22 @@ test("complex fields", (function() {
     var endXml = new XmlElement("w:r", {}, [
         new XmlElement("w:fldChar", {"w:fldCharType": "end"})
     ]);
+    var hyperlinkInstrText = new XmlElement("w:instrText", {}, [
+        xml.text(' HYPERLINK "' + uri + '"')
+    ]);
     
     return {
         "stores instrText returns empty result": function() {
-            var instrTextXml = new XmlElement("w:instrText", {}, [xml.text(' HYPERLINK "http://example.com"')]);
-            var instrText = readXmlElementValue(instrTextXml);
+            var instrText = readXmlElementValue(hyperlinkInstrText);
             assert.deepEqual(instrText, []);
         },
         
         "runs in a complex field for hyperlinks are read as hyperlinks": function() {
-            var instrTextXml = new XmlElement("w:instrText", {}, [xml.text(' HYPERLINK "' + uri + '"')]);
             var hyperlinkRunXml = runOfText("this is a hyperlink");
             var afterEndXml = runOfText("this will not be a hyperlink");
             var parXml = new XmlElement("w:p", {}, [
                 beginXml,
-                instrTextXml,
+                hyperlinkInstrText,
                 hyperlinkRunXml,
                 endXml,
                 afterEndXml

--- a/test/docx/comments-reader.tests.js
+++ b/test/docx/comments-reader.tests.js
@@ -1,14 +1,14 @@
 var assert = require("assert");
 
 var createCommentsReader = require("../../lib/docx/comments-reader").createCommentsReader;
-var BodyReader = require("../../lib/docx/body-reader").BodyReader;
+var createBodyReader = require("../../lib/docx/body-reader").createBodyReader;
 var documents = require("../../lib/documents");
 var xml = require("../../lib/xml");
 var test = require("../test")(module);
 
 
 function readComment(element) {
-    var bodyReader = new BodyReader({});
+    var bodyReader = createBodyReader({});
     var commentsReader = createCommentsReader(bodyReader);
     var comments = commentsReader(element);
     assert.equal(comments.value.length, 1);

--- a/test/docx/document-matchers.js
+++ b/test/docx/document-matchers.js
@@ -1,0 +1,27 @@
+var hamjest = require("hamjest");
+var _ = require("underscore");
+
+var documents = require("../../lib/documents");
+
+
+exports.isEmptyRun = isRun({children: []});
+exports.isRun = isRun;
+exports.isText = isText;
+exports.isHyperlink = isHyperlink;
+
+
+function isRun(properties) {
+    return isDocumentElement(documents.types.run, properties);
+}
+
+function isText(text) {
+    return isDocumentElement(documents.types.text, {value: text});
+}
+
+function isHyperlink(properties) {
+    return isDocumentElement(documents.types.hyperlink, properties);
+}
+
+function isDocumentElement(type, properties) {
+    return hamjest.hasProperties(_.extend({type: hamjest.equalTo(type)}, properties));
+}

--- a/test/docx/notes-reader.tests.js
+++ b/test/docx/notes-reader.tests.js
@@ -1,14 +1,14 @@
 var assert = require("assert");
 
 var createFootnotesReader = require("../../lib/docx/notes-reader").createFootnotesReader;
-var BodyReader = require("../../lib/docx/body-reader").BodyReader;
+var createBodyReader = require("../../lib/docx/body-reader").createBodyReader;
 var documents = require("../../lib/documents");
 var XmlElement = require("../../lib/xml").Element;
 var test = require("../test")(module);
 
 
 test('ID and body of footnote are read', function() {
-    var bodyReader = new BodyReader({});
+    var bodyReader = new createBodyReader({});
     var footnoteBody = [new XmlElement("w:p", {}, [])];
     var footnotes = createFootnotesReader(bodyReader)(
         new XmlElement("w:footnotes", {}, [


### PR DESCRIPTION
Currently hyperlinks defined with `w:hyperlink` work correctly, but other hyperlinks do not.

## Case 1 (working in master)

The following will look up the URI based on the `id` and works.
```xml
         <w:hyperlink r:id="rId5" w:history="1">
            <w:r w:rsidRPr="00E71B0C">
               <w:rPr>
                  <w:rStyle w:val="Hyperlink" />
               </w:rPr>
               <w:t>link</w:t>
            </w:r>
         </w:hyperlink>
```

## Case 2 (fixed by this PR)

The alternate case that this PR seeks to fix is:
```xml
      <w:p w14:paraId="163F3025" w14:textId="77777777" w:rsidR="00E71B0C" w:rsidRPr="00E71B0C" w:rsidRDefault="00E71B0C">
         <w:pPr>
            <w:rPr>
               <w:rStyle w:val="Hyperlink" />
            </w:rPr>
         </w:pPr>
         <w:r>
            <w:fldChar w:fldCharType="begin" />
         </w:r>
         <w:r>
            <w:instrText xml:space="preserve"> HYPERLINK "http://www.google.com/" </w:instrText>
         </w:r>
         <w:r>
            <w:fldChar w:fldCharType="separate" />
         </w:r>
         <w:r w:rsidRPr="00E71B0C">
            <w:rPr>
               <w:rStyle w:val="Hyperlink" />
            </w:rPr>
            <w:t>link to google</w:t>
         </w:r>
         <w:r>
            <w:fldChar w:fldCharType="end" />
         </w:r>
      </w:p>
```

## Solution

Both cases indicate that there is a hyperlink with `w:rStyle`, but the latter stores the URI in `w:instrText`. It seems that `w:instrText` can store a variety of data (`AUTHOR`, `DATE`, `HYPERLINK`, etc). It also appears that `w:fldChar` has an attribute `w:fldCharType` that indicates when that data "begins" and "ends". [Here](http://officeopenxml.com/WPfields.php) is some general information I found on these fields.

Essentially this approach stores `w:instrText` data such that it can be used in the correct context. Right now it is only used for hyperlinks, but we could easily add support for other use case (though the other cases I found like `AUTHOR`, and `DATE`, do not seem as useful to correctly render HTML). Whenever a `w:fldChar` with the attribute `w:fldCharType="end"` is hit, we can clear the `w:instrText` data as this field indicates that we are leaving the current context of this complex field, which prevents context from leaking where it should not be.

I added some tests and the code is fairly minimal, but let me know if you have any thoughts or suggestions for improving this solution.