### PR TITLE
Adding paragraph ids from DOCX document to HTML

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "taskName": "browserify:buid",
+      "command": "browserify",
+      "args": [
+         "lib/index.js",
+         "--standalone", "mammoth",
+         "-p", "browserify-prepend-licenses",
+         "-o", "mammoth.browser.js"
+      ],
+      "type": "shell",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,6 +17,13 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "taskName": "npm:install",
+      "command": "npm",
+      "args": [ "install" ],
+      "type": "shell",
+      "group": "build"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,8 @@
       "group": {
         "kind": "build",
         "isDefault": true
-      }
+      },
+      "problemMatcher": []
     },
     {
       "taskName": "npm:install",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,10 +7,13 @@
       "taskName": "browserify:buid",
       "command": "browserify",
       "args": [
-         "lib/index.js",
-         "--standalone", "mammoth",
-         "-p", "browserify-prepend-licenses",
-         "-o", "mammoth.browser.js"
+        "lib/index.js",
+        "--standalone",
+        "mammoth",
+        "-p",
+        "browserify-prepend-licenses",
+        "-o",
+        "mammoth.browser.js"
       ],
       "type": "shell",
       "group": {
@@ -21,9 +24,26 @@
     {
       "taskName": "npm:install",
       "command": "npm",
-      "args": [ "install" ],
+      "args": [
+        "install"
+      ],
       "type": "shell",
       "group": "build"
+    },
+    {
+      "taskName": "npm:test",
+      "command": "npm",
+      "args": [
+        "test"
+      ],
+      "type": "shell",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": [
+        "$eslint-compact"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -318,6 +318,18 @@ mammoth.convertToHtml({path: "path/to/document.docx"}, options);
 Comments will be appended to the end of the document,
 with links to the comments wrapped using the specified style mapping.
 
+#### Paragraph Ids
+
+By default, paragraphs does not contain ids from XML document.
+To include `data-para-id` (`paraId` from XML; if present) attribute to every paragraph in HTML document (which can be used later to find this exact paragraph in the original XML document), add option `paragraphId`.
+For instance:
+
+```javascript
+var options = {
+    paragraphId: true
+};
+```
+
 ### API
 
 #### `mammoth.convertToHtml(input, options)`
@@ -370,6 +382,9 @@ Converts the source document to HTML.
     this function is applied to the document read from the docx file before the conversion to HTML.
     The API for document transforms should be considered unstable.
     See [document transforms](#document-transforms).
+
+  * `paragraphId`: if set to true, every paragraph in HTML document will contain `data-para-id` attribute which matches `paraId` attribute in XML document.
+  By default it's false.
 
 * Returns a promise containing a result.
   This result has the following properties:

--- a/browser-demo/demo.js
+++ b/browser-demo/demo.js
@@ -4,9 +4,7 @@
         
     function handleFileSelect(event) {
         readFileInputEventAsArrayBuffer(event, function(arrayBuffer) {
-            mammoth.convertToHtml({ arrayBuffer: arrayBuffer }, {
-                paragraphId: true
-            })
+            mammoth.convertToHtml({ arrayBuffer: arrayBuffer })
                 .then(displayResult)
                 .done();
         });

--- a/browser-demo/demo.js
+++ b/browser-demo/demo.js
@@ -4,7 +4,7 @@
         
     function handleFileSelect(event) {
         readFileInputEventAsArrayBuffer(event, function(arrayBuffer) {
-            mammoth.convertToHtml({ arrayBuffer: arrayBuffer })
+            mammoth.convertToHtml({arrayBuffer: arrayBuffer})
                 .then(displayResult)
                 .done();
         });

--- a/browser-demo/demo.js
+++ b/browser-demo/demo.js
@@ -4,7 +4,9 @@
         
     function handleFileSelect(event) {
         readFileInputEventAsArrayBuffer(event, function(arrayBuffer) {
-            mammoth.convertToHtml({arrayBuffer: arrayBuffer}, { paragraphId: true })
+            mammoth.convertToHtml({ arrayBuffer: arrayBuffer }, {
+                paragraphId: true
+            })
                 .then(displayResult)
                 .done();
         });

--- a/browser-demo/demo.js
+++ b/browser-demo/demo.js
@@ -4,7 +4,7 @@
         
     function handleFileSelect(event) {
         readFileInputEventAsArrayBuffer(event, function(arrayBuffer) {
-            mammoth.convertToHtml({arrayBuffer: arrayBuffer})
+            mammoth.convertToHtml({arrayBuffer: arrayBuffer}, { paragraphId: true })
                 .then(displayResult)
                 .done();
         });

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -41,7 +41,9 @@ function DocumentConversion(options, comments) {
     function convertToHtml(document) {
         var messages = [];
         
-        var html = elementToHtml(document, messages, { paragraphId });
+        var html = elementToHtml(document, messages, {
+            paragraphId: paragraphId
+        });
         
         var deferredNodes = [];
         walkHtml(html, function(node) {
@@ -106,7 +108,9 @@ function DocumentConversion(options, comments) {
                 return [Html.forceWrite].concat(content);
             }
         });
-        if (paragraphId) { addIdToParagraph(res[0].tag.attributes, element); }
+        if (paragraphId) {
+            addIdToParagraph(res[0].tag.attributes, element);
+        }
         return res;
     }
     

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -101,7 +101,7 @@ function DocumentConversion(options, comments) {
     function convertParagraph(element, messages, options) {
         var res = htmlPathForParagraph(element, messages).wrap(function() {
             var content = convertElements(element.children, messages, options);
-            if (ignoreEmptyParagraphs && !paragraphId) {
+            if (ignoreEmptyParagraphs) {
                 return content;
             } else {
                 return [Html.forceWrite].concat(content);

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -36,8 +36,6 @@ function DocumentConversion(options, comments) {
     var ignoreEmptyParagraphs = options.ignoreEmptyParagraphs;
     var paragraphId = options.paragraphId || false;
     
-    var defaultParagraphStyle = htmlPaths.topLevelElement("p");
-    
     var styleMap = options.styleMap || [];
     
     function convertToHtml(document) {
@@ -103,7 +101,7 @@ function DocumentConversion(options, comments) {
     function convertParagraph(element, messages, options) {
         var res = htmlPathForParagraph(element, messages).wrap(function() {
             var content = convertElements(element.children, messages, options);
-            if (ignoreEmptyParagraphs) {
+            if (ignoreEmptyParagraphs && !paragraphId) {
                 return content;
             } else {
                 return [Html.forceWrite].concat(content);
@@ -121,7 +119,7 @@ function DocumentConversion(options, comments) {
             if (element.styleId) {
                 messages.push(unrecognisedStyleWarning("paragraph", element));
             }
-            return defaultParagraphStyle;
+            return htmlPaths.topLevelElement("p");
         }
     }
     
@@ -192,7 +190,7 @@ function DocumentConversion(options, comments) {
     }
 
     function addIdToParagraph(attributes, element) {
-        if (!attributes["data-para-id"] && element.attributes.paraId) {
+        if (element.attributes.paraId) {
             attributes["data-para-id"] = element.attributes.paraId;
         }
     }

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -109,7 +109,7 @@ function DocumentConversion(options, comments) {
                 return [Html.forceWrite].concat(content);
             }
         });
-        if (paragraphId) { addIdToParagraph(res[0].tag, element); }
+        if (paragraphId) { addIdToParagraph(res[0].tag.attributes, element); }
         return res;
     }
     
@@ -191,9 +191,9 @@ function DocumentConversion(options, comments) {
         }
     }
 
-    function addIdToParagraph(tag, element) {
-        if (tag.attributes["data-para-id"] && element.attributes.paraId) {
-            tag.attributes["data-para-id"] = element.attributes.paraId;
+    function addIdToParagraph(attributes, element) {
+        if (!attributes["data-para-id"] && element.attributes.paraId) {
+            attributes["data-para-id"] = element.attributes.paraId;
         }
     }
     

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -194,7 +194,7 @@ function DocumentConversion(options, comments) {
     }
 
     function addIdToParagraph(attributes, element) {
-        if (element.attributes.paraId) {
+        if (element.attributes && element.attributes.paraId) {
             attributes["data-para-id"] = element.attributes.paraId;
         }
     }

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -91,8 +91,7 @@ function DocumentConversion(options, comments) {
         }
         var handler = elementConverters[element.type];
         if (handler) {
-            var content = handler(element, messages, options);
-            return content;
+            return handler(element, messages, options);
         } else {
             return [];
         }
@@ -113,6 +112,7 @@ function DocumentConversion(options, comments) {
     
     function htmlPathForParagraph(element, messages) {
         var style = findStyle(element);
+        
         if (style) {
             return style.to;
         } else {

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -34,6 +34,7 @@ function DocumentConversion(options, comments) {
     options = _.extend({ignoreEmptyParagraphs: true}, options);
     var idPrefix = options.idPrefix === undefined ? "" : options.idPrefix;
     var ignoreEmptyParagraphs = options.ignoreEmptyParagraphs;
+    var paragraphId = options.paragraphId || false;
     
     var defaultParagraphStyle = htmlPaths.topLevelElement("p");
     
@@ -42,7 +43,7 @@ function DocumentConversion(options, comments) {
     function convertToHtml(document) {
         var messages = [];
         
-        var html = elementToHtml(document, messages, {});
+        var html = elementToHtml(document, messages, { paragraphId });
         
         var deferredNodes = [];
         walkHtml(html, function(node) {
@@ -92,14 +93,15 @@ function DocumentConversion(options, comments) {
         }
         var handler = elementConverters[element.type];
         if (handler) {
-            return handler(element, messages, options);
+            var content = handler(element, messages, options);
+            return content;
         } else {
             return [];
         }
     }
     
     function convertParagraph(element, messages, options) {
-        return htmlPathForParagraph(element, messages).wrap(function() {
+        var res = htmlPathForParagraph(element, messages).wrap(function() {
             var content = convertElements(element.children, messages, options);
             if (ignoreEmptyParagraphs) {
                 return content;
@@ -107,11 +109,14 @@ function DocumentConversion(options, comments) {
                 return [Html.forceWrite].concat(content);
             }
         });
+        if (options.paragraphId && element.attributes && element.attributes.paraId) {
+            res[0].tag.attributes["data-para-id"] = element.attributes.paraId;
+        }
+        return res;
     }
     
     function htmlPathForParagraph(element, messages) {
         var style = findStyle(element);
-        
         if (style) {
             return style.to;
         } else {

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -109,9 +109,7 @@ function DocumentConversion(options, comments) {
                 return [Html.forceWrite].concat(content);
             }
         });
-        if (options.paragraphId && element.attributes && element.attributes.paraId) {
-            res[0].tag.attributes["data-para-id"] = element.attributes.paraId;
-        }
+        if (paragraphId) { addIdToParagraph(res[0].tag, element); }
         return res;
     }
     
@@ -190,6 +188,12 @@ function DocumentConversion(options, comments) {
             if (styleMap[i].from.matches(element)) {
                 return styleMap[i];
             }
+        }
+    }
+
+    function addIdToParagraph(tag, element) {
+        if (tag.attributes["data-para-id"] && element.attributes.paraId) {
+            tag.attributes["data-para-id"] = element.attributes.paraId;
         }
     }
     

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -30,8 +30,6 @@ function Document(children, options) {
 }
 
 function Paragraph(children, properties) {
-    console.log(children);
-    console.log(properties);
     properties = properties || {};
     return {
         type: types.paragraph,

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -30,6 +30,8 @@ function Document(children, options) {
 }
 
 function Paragraph(children, properties) {
+    console.log(children);
+    console.log(properties);
     properties = properties || {};
     return {
         type: types.paragraph,

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -37,7 +37,8 @@ function Paragraph(children, properties) {
         styleId: properties.styleId || null,
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
-        alignment: properties.alignment || null
+        alignment: properties.alignment || null,
+        attributes: properties.attributes || null
     };
 }
 

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -80,6 +80,18 @@ function BodyReader(options) {
     function readRunStyle(element) {
         return readStyle(element, "w:rStyle", "Run", styles.findCharacterStyleById);
     }
+
+    function readAttributes(element) {
+        var attributes = {};
+        for (var attr in element.attributes) {
+            if (!element.attributes.hasOwnProperty(attr)) { continue; }
+            var attrName = attr
+                .split(/w:|{.*}/i)
+                .filter(function (s) { return s !== "" })[0];
+            attributes[attrName] = element.attributes[attr];
+        }
+        return attributes;
+    }
     
     function readStyle(element, styleTagName, styleType, findStyleById) {
         var messages = [];
@@ -160,10 +172,12 @@ function BodyReader(options) {
     }
     
     var xmlElementReaders = {
-        "w:p": function(element) {
+        "w:p": function (element) {
+            var attributes = readAttributes(element);
             return readXmlElements(element.children)
                 .map(function(children) {
                     var properties = _.find(children, isParagraphProperties);
+                    if (properties) { properties.attributes = attributes; }
                     return new documents.Paragraph(
                         children.filter(negate(isParagraphProperties)),
                         properties

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -93,7 +93,7 @@ function BodyReader(options) {
                 attributes[attrName] = element.attributes[attr];
             }
         }
-        return attributes.hasOwnProperty() ? attributes : null;
+        return attributes;
     }
     
     function readStyle(element, styleTagName, styleType, findStyleById) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -84,11 +84,14 @@ function BodyReader(options) {
     function readAttributes(element) {
         var attributes = {};
         for (var attr in element.attributes) {
-            if (!element.attributes.hasOwnProperty(attr)) { continue; }
-            var attrName = attr
-                .split(/w:|{.*}/i)
-                .filter(function (s) { return s !== "" })[0];
-            attributes[attrName] = element.attributes[attr];
+            if (element.attributes.hasOwnProperty(attr)) {
+                var attrName = attr
+                    .split(/w:|{.*}/i)
+                    .filter(function(s) {
+                        return s !== "";
+                    })[0];
+                attributes[attrName] = element.attributes[attr];
+            }
         }
         return attributes;
     }

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -93,7 +93,7 @@ function BodyReader(options) {
                 attributes[attrName] = element.attributes[attr];
             }
         }
-        return attributes;
+        return attributes.hasOwnProperty() ? attributes : null;
     }
     
     function readStyle(element, styleTagName, styleType, findStyleById) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -176,8 +176,8 @@ function BodyReader(options) {
             var attributes = readAttributes(element);
             return readXmlElements(element.children)
                 .map(function(children) {
-                    var properties = _.find(children, isParagraphProperties);
-                    if (properties) { properties.attributes = attributes; }
+                    var properties = _.find(children, isParagraphProperties) || {};
+                    properties.attributes = attributes;
                     return new documents.Paragraph(
                         children.filter(negate(isParagraphProperties)),
                         properties

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -172,15 +172,15 @@ function BodyReader(options) {
     }
     
     var xmlElementReaders = {
-        "w:p": function (element) {
+        "w:p": function(element) {
             var attributes = readAttributes(element);
             return readXmlElements(element.children)
                 .map(function(children) {
-                    var properties = _.find(children, isParagraphProperties) || {};
-                    properties.attributes = attributes;
+                    var props = _.find(children, isParagraphProperties) || {};
+                    props.attributes = attributes;
                     return new documents.Paragraph(
                         children.filter(negate(isParagraphProperties)),
-                        properties
+                        props
                     );
                 })
                 .insertExtra();

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "pretest": "eslint lib tests",
-    "test": "mocha 'test/**/*.tests.js'",
+    "test": "mocha test/**/*.tests.js",
     "prepublish": "make mammoth.browser.min.js"
   },
   "license": "BSD-2-Clause"

--- a/test/docx/files.tests.js
+++ b/test/docx/files.tests.js
@@ -43,7 +43,7 @@ test("Files", {
     "error if relative uri cannot be opened": function() {
         var files = new Files("/tmp");
         return assertError(files.read("not-a-real-file.png", "base64"), function(err) {
-            assertRegex(err.message, /could not open external image: 'not-a-real-file.png' \(document directory: '\/tmp'\)\nENOENT.*\/tmp\/not-a-real-file.png.*/);
+            assertRegex(err.message, /could not open external image: 'not-a-real-file.png' \(document directory: '\/tmp'\)\nENOENT.*(\/|\\)tmp(\/|\\)not-a-real-file.png.*/);
         });
     }
 });


### PR DESCRIPTION
Hi! I needed to modify library so it can meet my needs more now. In project I'm making I have to display comments in the document which this library actually is able to do but aside of that there is no way to send information to my back-end API with reliably position of a new comment to add to the document.

I fixed that adding a new option with possibility to render additional attribute in `p` tags with `paraId` attribute from original XML document as neutral `data-para-id` HTML attribute so I can match rendered HTML paragraph with original one. The way to enable it is added to `README`.

I had to make some changes in few files to make everything work. I spend most of the time wondering how it is actually working cause I use mostly TypeScript every day which is much easier to debug and understand the code written in it.

This pull request is my working proposition to implement this feature that I would be very grateful to see in. In addition I have made comment range rendering #128 at a new fresh branch so I would specify where the comment starts and ends in HTML document.