### PR TITLE
Parse Paragraph Indents

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -39,10 +39,10 @@ function Paragraph(children, properties) {
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
         indent: {
-            left: properties.indent.left || null,
-            right: properties.indent.right || null,
-            firstLine: properties.indent.firstLine || null,
-            hanging: properties.indent.hanging || null
+            left: _.has(properties, 'indent') ? properties.indent.left || null : null,
+            right: _.has(properties, 'indent') ? properties.indent.right || null : null,
+            firstLine: _.has(properties, 'indent') ? properties.indent.firstLine || null : null,
+            hanging: _.has(properties, 'indent') ? properties.indent.hanging || null : null
         }
     };
 }

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -38,12 +38,12 @@ function Paragraph(children, properties) {
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
-	    indent: {
-		    left: properties.indent.left || null,
-		    right: properties.indent.right || null,
-		    firstLine: properties.indent.firstLine || null,
-		    hanging: properties.indent.hanging || null		    
-	    }
+        indent: {
+            left: properties.indent.left || null,
+            right: properties.indent.right || null,
+            firstLine: properties.indent.firstLine || null,
+            hanging: properties.indent.hanging || null		    
+        }
     };
 }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -39,10 +39,10 @@ function Paragraph(children, properties) {
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
         indent: {
-            left: properties.indent.left || null,
-            right: properties.indent.right || null,
-            firstLine: properties.indent.firstLine || null,
-            hanging: properties.indent.hanging || null
+            left: properties.indentLeft || null,
+            right: properties.indentRight || null,
+            firstLine: properties.indentFirstLine || null,
+            hanging: properties.indentHanging || null
         }
     };
 }

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -31,20 +31,30 @@ function Document(children, options) {
 
 function Paragraph(children, properties) {
     properties = properties || {};
-    return {
+    var p = {
         type: types.paragraph,
         children: children,
         styleId: properties.styleId || null,
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
-        alignment: properties.alignment || null,
-        indent: {
-            left: properties.indent.left || null,
-            right: properties.indent.right || null,
-            firstLine: properties.indent.firstLine || null,
-            hanging: properties.indent.hanging || null
-        }
+        alignment: properties.alignment || null
     };
+    
+    if (properties["indent"]) {
+        if (properties.indent.left) {
+            p.indent.left = properties.indent.left;
+        }
+        if (properties.indent.right) {
+            p.indent.right = properties.indent.right;
+        }
+        if (properties.indent.firstLine) {
+            p.indent.firstLine = properties.indent.firstLine;
+        }
+        if (properties.indent.hanging) {
+            p.indent.hanging = properties.indent.hanging;
+        }
+    }
+    return p;
 }
 
 function Run(children, properties) {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -39,10 +39,10 @@ function Paragraph(children, properties) {
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
         indent: {
-            left: properties.indentLeft || null,
-            right: properties.indentRight || null,
-            firstLine: properties.indentFirstLine || null,
-            hanging: properties.indentHanging || null
+            left: properties.indent.left || null,
+            right: properties.indent.right || null,
+            firstLine: properties.indent.firstLine || null,
+            hanging: properties.indent.hanging || null
         }
     };
 }

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -31,35 +31,20 @@ function Document(children, options) {
 
 function Paragraph(children, properties) {
     properties = properties || {};
-    var p = {
+    return {
         type: types.paragraph,
         children: children,
         styleId: properties.styleId || null,
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
-        alignment: properties.alignment || null
+        alignment: properties.alignment || null,
+	    indent: {
+		    left: properties.indent.left || null,
+		    right: properties.indent.right || null,
+		    firstLine: properties.indent.firstLine || null,
+		    hanging: properties.indent.hanging || null		    
+	    }
     };
-    
-    var indent = {};
-    if (_.has(properties, "indent")) {
-        if (properties.indent.left) {
-            indent["left"] = properties.indent.left;
-        }
-        if (properties.indent.right) {
-            indent["right"] = properties.indent.right;
-        }
-        if (properties.indent.firstLine) {
-            indent["firstLine"] = properties.indent.firstLine;
-        }
-        if (properties.indent.hanging) {
-            indent["hanging"] = properties.indent.hanging;
-        }
-    }
-				
-    if (!_.isEmpty(indent)) {
-        p.indent = indent;
-    }
-    return p;
 }
 
 function Run(children, properties) {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -40,8 +40,8 @@ function Paragraph(children, properties) {
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
         indent: {
-            left: indent.left || null,
-            right: indent.right || null,
+            start: indent.start || null,
+            end: indent.end || null,
             firstLine: indent.firstLine || null,
             hanging: indent.hanging || null
         }

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -42,7 +42,7 @@ function Paragraph(children, properties) {
             left: properties.indent.left || null,
             right: properties.indent.right || null,
             firstLine: properties.indent.firstLine || null,
-            hanging: properties.indent.hanging || null		    
+            hanging: properties.indent.hanging || null
         }
     };
 }

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -38,10 +38,12 @@ function Paragraph(children, properties) {
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
-        indentLeft: properties.indentLeft || null,
-        indentRight: properties.indentRight || null,
-        indentFirstLine: properties.indentFirstLine || null,
-        indentHanging: properties.indentHanging || null
+        indent: {
+            left: properties.indent.left || null,
+            right: properties.indent.right || null,
+            firstLine: properties.indent.firstLine || null,
+            hanging: properties.indent.hanging || null
+        }
     };
 }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -40,7 +40,7 @@ function Paragraph(children, properties) {
         alignment: properties.alignment || null
     };
     
-	var indent = {};
+    var indent = {};
     if (_.has(properties, "indent")) {
         if (properties.indent.left) {
             indent["left"] = properties.indent.left;

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -40,20 +40,25 @@ function Paragraph(children, properties) {
         alignment: properties.alignment || null
     };
     
-    if (properties["indent"]) {
+	var indent = {};
+    if (_.has(properties, "indent")) {
         if (properties.indent.left) {
-            p.indent.left = properties.indent.left;
+            indent["left"] = properties.indent.left;
         }
         if (properties.indent.right) {
-            p.indent.right = properties.indent.right;
+            indent["right"] = properties.indent.right;
         }
         if (properties.indent.firstLine) {
-            p.indent.firstLine = properties.indent.firstLine;
+            indent["firstLine"] = properties.indent.firstLine;
         }
         if (properties.indent.hanging) {
-            p.indent.hanging = properties.indent.hanging;
+            indent["hanging"] = properties.indent.hanging;
         }
     }
+				
+	if (!_.isEmpty(indent)) {
+		p.indent = indent;
+	}
     return p;
 }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -40,7 +40,7 @@ function Paragraph(children, properties) {
         alignment: properties.alignment || null
     };
     
-    var indent = {};
+	var indent = {};
     if (_.has(properties, "indent")) {
         if (properties.indent.left) {
             indent["left"] = properties.indent.left;

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -40,7 +40,7 @@ function Paragraph(children, properties) {
         alignment: properties.alignment || null
     };
     
-	var indent = {};
+    var indent = {};
     if (_.has(properties, "indent")) {
         if (properties.indent.left) {
             indent["left"] = properties.indent.left;
@@ -56,9 +56,9 @@ function Paragraph(children, properties) {
         }
     }
 				
-	if (!_.isEmpty(indent)) {
-		p.indent = indent;
-	}
+    if (!_.isEmpty(indent)) {
+        p.indent = indent;
+    }
     return p;
 }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -37,7 +37,11 @@ function Paragraph(children, properties) {
         styleId: properties.styleId || null,
         styleName: properties.styleName || null,
         numbering: properties.numbering || null,
-        alignment: properties.alignment || null
+        alignment: properties.alignment || null,
+        indentLeft: properties.indentLeft || null,
+        indentRight: properties.indentRight || null,
+        indentFirstLine: properties.indentFirstLine || null,
+        indentHanging: properties.indentHanging || null
     };
 }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -31,6 +31,7 @@ function Document(children, options) {
 
 function Paragraph(children, properties) {
     properties = properties || {};
+    var indent = properties.indent || {};
     return {
         type: types.paragraph,
         children: children,
@@ -39,10 +40,10 @@ function Paragraph(children, properties) {
         numbering: properties.numbering || null,
         alignment: properties.alignment || null,
         indent: {
-            left: _.has(properties, 'indent') ? properties.indent.left || null : null,
-            right: _.has(properties, 'indent') ? properties.indent.right || null : null,
-            firstLine: _.has(properties, 'indent') ? properties.indent.firstLine || null : null,
-            hanging: _.has(properties, 'indent') ? properties.indent.hanging || null : null
+            left: indent.left || null,
+            right: indent.right || null,
+            firstLine: indent.firstLine || null,
+            hanging: indent.hanging || null
         }
     };
 }

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -178,10 +178,12 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                    indentLeft: element.firstOrEmpty("w:ind").attributes["w:left"],
-                    indentRight: element.firstOrEmpty("w:ind").attributes["w:right"],
-                    indentFirstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                    indentHanging: element.firstOrEmpty("w:ind").attributes["w:hanging"],
+                    indent: {
+                        left: element.firstOrEmpty("w:ind").attributes["w:left"],
+                        right: element.firstOrEmpty("w:ind").attributes["w:right"],
+                        firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                        hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
+                    },
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
             });

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -173,19 +173,36 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
-                return {
+				var pS = {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                    indent: {
-                        left: element.firstOrEmpty("w:ind").attributes["w:left"],
-                        right: element.firstOrEmpty("w:ind").attributes["w:right"],
-                        firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                        hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
-                    },
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
+				
+				var left = element.firstOrEmpty("w:ind").attributes["w:left"];
+                var right = element.firstOrEmpty("w:ind").attributes["w:right"];
+                var firstLine = element.firstOrEmpty("w:ind").attributes["w:firstLine"];
+                var hanging = element.firstOrEmpty("w:ind").attributes["w:hanging"];
+				var indent = {};
+                if (left) {
+                    indent["left"] = left;
+				}
+				if (right) {
+                    indent["right"] = right;
+				}
+				if (firstLine) {
+                    indent["firstLine"] = firstLine;
+				}
+				if (hanging) {
+                    indent["hanging"] = hanging;
+				}
+				
+				if (!_.isEmpty(indent)) {
+					pS.indent = indent;
+				}
+				return pS;
             });
         },
         "w:r": function(element) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -47,6 +47,15 @@ function BodyReader(options) {
         return emptyResult();
     }
     
+    function readParagraphIndent(element) {
+        return {
+            start: element.attributes["w:start"] || element.attributes["w:left"],
+            end: element.attributes["w:end"] || element.attributes["w:right"],
+            firstLine: element.attributes["w:firstLine"],
+            hanging: element.attributes["w:hanging"]
+        };
+    }
+    
     function readRunProperties(element) {
         return readRunStyle(element).map(function(style) {
             return {
@@ -179,12 +188,7 @@ function BodyReader(options) {
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering),
-                    indent: {
-                        start: element.firstOrEmpty("w:ind").attributes["w:left"],
-                        end: element.firstOrEmpty("w:ind").attributes["w:right"],
-                        firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                        hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
-                    }
+                    indent: readParagraphIndent(element.firstOrEmpty("w:ind"))
                 };
             });
         },

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -178,12 +178,10 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                    indent: {
-                        left: element.firstOrEmpty("w:ind").attributes["w:left"],
-                        right: element.firstOrEmpty("w:ind").attributes["w:right"],
-                        firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                        hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
-                    },
+                    indentLeft: element.firstOrEmpty("w:ind").attributes["w:left"],
+                    indentRight: element.firstOrEmpty("w:ind").attributes["w:right"],
+                    indentFirstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                    indentHanging: element.firstOrEmpty("w:ind").attributes["w:hanging"],
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
             });

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -173,7 +173,7 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
-                 var pStyle = {
+                var pStyle = {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -178,13 +178,13 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                        indent: {
-                                left: element.firstOrEmpty("w:ind").attributes["w:left"],
-                                right: element.firstOrEmpty("w:ind").attributes["w:right"],
-                                firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                                hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
-                        },
-                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
+                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering),
+                    indent: {
+                        left: element.firstOrEmpty("w:ind").attributes["w:left"],
+                        right: element.firstOrEmpty("w:ind").attributes["w:right"],
+                        firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                        hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
+                    }
                 };
             });
         },

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -178,6 +178,10 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
+                    indentLeft: element.firstOrEmpty("w:ind").attributes["w:left"],
+                    indentRight: element.firstOrEmpty("w:ind").attributes["w:right"],
+                    indentFirstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                    indentHanging: element.firstOrEmpty("w:ind").attributes["w:hanging"],
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
             });

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -178,12 +178,12 @@ function BodyReader(options) {
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-			indent: {
-				left: element.firstOrEmpty("w:ind").attributes["w:left"],
-				right: element.firstOrEmpty("w:ind").attributes["w:right"],
-                		firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
-                		hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
-			},
+                        indent: {
+                                left: element.firstOrEmpty("w:ind").attributes["w:left"],
+                                right: element.firstOrEmpty("w:ind").attributes["w:right"],
+                                firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                                hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
+                        },
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
             });

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -180,8 +180,8 @@ function BodyReader(options) {
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering),
                     indent: {
-                        left: element.firstOrEmpty("w:ind").attributes["w:left"],
-                        right: element.firstOrEmpty("w:ind").attributes["w:right"],
+                        start: element.firstOrEmpty("w:ind").attributes["w:left"],
+                        end: element.firstOrEmpty("w:ind").attributes["w:right"],
                         firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
                         hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
                     }

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -173,7 +173,7 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
-				var pS = {
+				var pStyle = {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,
@@ -200,9 +200,9 @@ function BodyReader(options) {
 				}
 				
 				if (!_.isEmpty(indent)) {
-					pS.indent = indent;
+					pStyle.indent = indent;
 				}
-				return pS;
+				return pStyle;
             });
         },
         "w:r": function(element) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -173,36 +173,19 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
-                var pStyle = {
+                return {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
+			indent: {
+				left: element.firstOrEmpty("w:ind").attributes["w:left"],
+				right: element.firstOrEmpty("w:ind").attributes["w:right"],
+                		firstLine: element.firstOrEmpty("w:ind").attributes["w:firstLine"],
+                		hanging: element.firstOrEmpty("w:ind").attributes["w:hanging"]
+			},
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
-				
-                var left = element.firstOrEmpty("w:ind").attributes["w:left"];
-                var right = element.firstOrEmpty("w:ind").attributes["w:right"];
-                var firstLine = element.firstOrEmpty("w:ind").attributes["w:firstLine"];
-                var hanging = element.firstOrEmpty("w:ind").attributes["w:hanging"];
-                var indent = {};
-                if (left) {
-                    indent["left"] = left;
-                }
-                if (right) {
-                    indent["right"] = right;
-                }
-                if (firstLine) {
-                    indent["firstLine"] = firstLine;
-                }
-                if (hanging) {
-                    indent["hanging"] = hanging;
-                }
-				
-                if (!_.isEmpty(indent)) {
-                    pStyle.indent = indent;
-                }
-                return pStyle;
             });
         },
         "w:r": function(element) {

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -173,7 +173,7 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
-				var pStyle = {
+                 var pStyle = {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,
@@ -181,28 +181,28 @@ function BodyReader(options) {
                     numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering)
                 };
 				
-				var left = element.firstOrEmpty("w:ind").attributes["w:left"];
+                var left = element.firstOrEmpty("w:ind").attributes["w:left"];
                 var right = element.firstOrEmpty("w:ind").attributes["w:right"];
                 var firstLine = element.firstOrEmpty("w:ind").attributes["w:firstLine"];
                 var hanging = element.firstOrEmpty("w:ind").attributes["w:hanging"];
-				var indent = {};
+                var indent = {};
                 if (left) {
                     indent["left"] = left;
-				}
-				if (right) {
+                }
+                if (right) {
                     indent["right"] = right;
-				}
-				if (firstLine) {
+                }
+                if (firstLine) {
                     indent["firstLine"] = firstLine;
-				}
-				if (hanging) {
+                }
+                if (hanging) {
                     indent["hanging"] = hanging;
-				}
+                }
 				
-				if (!_.isEmpty(indent)) {
-					pStyle.indent = indent;
-				}
-				return pStyle;
+                if (!_.isEmpty(indent)) {
+                    pStyle.indent = indent;
+                }
+                return pStyle;
             });
         },
         "w:r": function(element) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -121,7 +121,7 @@ test("paragraph has indent hanging read from paragraph properties if present", f
 test("paragraph has no indent read from paragraph properties", function() {
     var paragraphXml = paragraphWithIndent({});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent, null);
+    assert.deepEqual(paragraph.indent, undefined);
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -94,22 +94,35 @@ test("paragraph has justification read from paragraph properties if present", fu
     assert.deepEqual(paragraph.alignment, "center");
 });
 
-var indentProperties = [
-    {name: "left", value: {"w:left": "720"}},
-    {name: "right", value: {"w:right": "180"}},
-    {name: "firstLine", value: {"w:firstLine": "320"}},
-    {name: "hanging", value: {"w:hanging": "500"}}
-];
-
-indentProperties.forEach(function(property) {
-    test("paragraph has indent " + property.name + " read from paragraph properties if present", function() {
-        var indentXml = new XmlElement("w:ind", property.value, []);
-        var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
-        var paragraphXml = new XmlElement("w:p", {}, [propertiesXml]);
-        var paragraph = readXmlElementValue(paragraphXml);
-        assert.deepEqual(paragraph.indent[property.name], property.value[Object.keys(property.value)[0]]);
-    });
+test("paragraph has indent left read from paragraph properties if present", function() {
+    var paragraphXml = paragraphWithIndent({"w:left": "720"});
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.equal(paragraph.indent.left, "720");
 });
+
+test("paragraph has indent right read from paragraph properties if present", function() {
+    var paragraphXml = paragraphWithIndent({"w:right": "720"});
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.equal(paragraph.indent.right, "720");
+});
+
+test("paragraph has indent firstLine read from paragraph properties if present", function() {
+    var paragraphXml = paragraphWithIndent({"w:fistLine": "720"});
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.equal(paragraph.indent.firstLine, "720");
+});
+
+test("paragraph has indent hanging read from paragraph properties if present", function() {
+    var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.equal(paragraph.indent.hanging, "720");
+});
+
+function paragraphWithIndent(indentAttributes) {
+    var indentXml = new XmlElement("w:ind", indentAttributes, []);
+    var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
+    return new XmlElement("w:p", {}, [propertiesXml]);
+}
 
 test("paragraph has numbering properties from paragraph properties if present", function() {
     var numberingPropertiesXml = new XmlElement("w:numPr", {}, [

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -97,34 +97,34 @@ test("paragraph has justification read from paragraph properties if present", fu
 test("paragraph has indent left read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:left": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent.left, "720");
+    assert.equal(paragraph.indent.left, "720");
 });
 
 test("paragraph has indent right read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:right": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent.right, "720");
+    assert.equal(paragraph.indent.right, "720");
 });
 
 test("paragraph has indent firstLine read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:firstLine": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent.firstLine, "720");
+    assert.equal(paragraph.indent.firstLine, "720");
 });
 
 test("paragraph has indent hanging read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent.hanging, "720");
+    assert.equal(paragraph.indent.hanging, "720");
 });
 
-test("paragraph has no indent read from paragraph properties", function() {
+test("when indent attributes aren't set then indents are null", function() {
     var paragraphXml = paragraphWithIndent({});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent.left, null);
-    assert.deepEqual(paragraph.indent.right, null);
-    assert.deepEqual(paragraph.indent.firstLine, null);
-    assert.deepEqual(paragraph.indent.hanging, null);
+    assert.equal(paragraph.indent.left, null);
+    assert.equal(paragraph.indent.right, null);
+    assert.equal(paragraph.indent.firstLine, null);
+    assert.equal(paragraph.indent.hanging, null);
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -107,7 +107,7 @@ test("paragraph has indent right read from paragraph properties if present", fun
 });
 
 test("paragraph has indent firstLine read from paragraph properties if present", function() {
-    var paragraphXml = paragraphWithIndent({"w:fistLine": "720"});
+    var paragraphXml = paragraphWithIndent({"w:firstLine": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
     assert.deepEqual(paragraph.indent.firstLine, "720");
 });
@@ -116,6 +116,12 @@ test("paragraph has indent hanging read from paragraph properties if present", f
     var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
     assert.deepEqual(paragraph.indent.hanging, "720");
+});
+
+test("paragraph has no indent read from paragraph properties", function() {
+    var paragraphXml = paragraphWithIndent({});
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.deepEqual(paragraph.indent, null);
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -94,37 +94,39 @@ test("paragraph has justification read from paragraph properties if present", fu
     assert.deepEqual(paragraph.alignment, "center");
 });
 
-test("paragraph has indent left read from paragraph properties if present", function() {
-    var paragraphXml = paragraphWithIndent({"w:left": "720"});
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.start, "720");
-});
+test("paragraph indent", {
+    "paragraph has indent left read from paragraph properties if present": function() {
+        var paragraphXml = paragraphWithIndent({"w:left": "720"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.start, "720");
+    },
 
-test("paragraph has indent right read from paragraph properties if present", function() {
-    var paragraphXml = paragraphWithIndent({"w:right": "720"});
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.end, "720");
-});
+    "paragraph has indent right read from paragraph properties if present": function() {
+        var paragraphXml = paragraphWithIndent({"w:right": "720"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.end, "720");
+    },
 
-test("paragraph has indent firstLine read from paragraph properties if present", function() {
-    var paragraphXml = paragraphWithIndent({"w:firstLine": "720"});
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.firstLine, "720");
-});
+    "paragraph has indent firstLine read from paragraph properties if present": function() {
+        var paragraphXml = paragraphWithIndent({"w:firstLine": "720"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.firstLine, "720");
+    },
 
-test("paragraph has indent hanging read from paragraph properties if present", function() {
-    var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.hanging, "720");
-});
+    "paragraph has indent hanging read from paragraph properties if present": function() {
+        var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.hanging, "720");
+    },
 
-test("when indent attributes aren't set then indents are null", function() {
-    var paragraphXml = paragraphWithIndent({});
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.left, null);
-    assert.equal(paragraph.indent.right, null);
-    assert.equal(paragraph.indent.firstLine, null);
-    assert.equal(paragraph.indent.hanging, null);
+    "when indent attributes aren't set then indents are null": function() {
+        var paragraphXml = paragraphWithIndent({});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.left, null);
+        assert.equal(paragraph.indent.right, null);
+        assert.equal(paragraph.indent.firstLine, null);
+        assert.equal(paragraph.indent.hanging, null);
+    }
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -97,25 +97,25 @@ test("paragraph has justification read from paragraph properties if present", fu
 test("paragraph has indent left read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:left": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.left, "720");
+    assert.deepEqual(paragraph.indent.left, "720");
 });
 
 test("paragraph has indent right read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:right": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.right, "720");
+    assert.deepEqual(paragraph.indent.right, "720");
 });
 
 test("paragraph has indent firstLine read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:fistLine": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.firstLine, "720");
+    assert.deepEqual(paragraph.indent.firstLine, "720");
 });
 
 test("paragraph has indent hanging read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:hanging": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.hanging, "720");
+    assert.deepEqual(paragraph.indent.hanging, "720");
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -94,6 +94,17 @@ test("paragraph has justification read from paragraph properties if present", fu
     assert.deepEqual(paragraph.alignment, "center");
 });
 
+test("paragraph has indent read from paragraph properties if present (Left, Right, First Line & Hanging)", function() {
+    var indentXml = new XmlElement("w:ind", {"w:left": "720", "w:right": "720", "w:firstLine": "720", "w:hanging": "720"}, []);
+    var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
+    var paragraphXml = new XmlElement("w:p", {}, [propertiesXml]);
+    var paragraph = readXmlElementValue(paragraphXml);
+    assert.deepEqual(paragraph.indentLeft, "720");
+    assert.deepEqual(paragraph.indentRight, "720");
+    assert.deepEqual(paragraph.indentFirstLine, "720");
+    assert.deepEqual(paragraph.indentHanging, "720");
+});
+
 test("paragraph has numbering properties from paragraph properties if present", function() {
     var numberingPropertiesXml = new XmlElement("w:numPr", {}, [
         new XmlElement("w:ilvl", {"w:val": "1"}),

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -94,15 +94,21 @@ test("paragraph has justification read from paragraph properties if present", fu
     assert.deepEqual(paragraph.alignment, "center");
 });
 
-test("paragraph has indent read from paragraph properties if present (Left, Right, First Line & Hanging)", function() {
-    var indentXml = new XmlElement("w:ind", {"w:left": "720", "w:right": "720", "w:firstLine": "720", "w:hanging": "720"}, []);
-    var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
-    var paragraphXml = new XmlElement("w:p", {}, [propertiesXml]);
-    var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indentLeft, "720");
-    assert.deepEqual(paragraph.indentRight, "720");
-    assert.deepEqual(paragraph.indentFirstLine, "720");
-    assert.deepEqual(paragraph.indentHanging, "720");
+var indentProperties = [
+    {name: "left", value: {"w:left": "720"}},
+    {name: "right", value: {"w:right": "180"}},
+    {name: "firstLine", value: {"w:firstLine": "320"}},
+    {name: "hanging", value: {"w:hanging": "500"}}
+];
+
+indentProperties.forEach(function(property) {
+    test("paragraph has indent " + property.name + " read from paragraph properties if present", function() {
+        var indentXml = new XmlElement("w:ind", property.value, []);
+        var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
+        var paragraphXml = new XmlElement("w:p", {}, [propertiesXml]);
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.deepEqual(paragraph.indent[name], property.value[Object.keys(property.value)[0]]);
+    });
 });
 
 test("paragraph has numbering properties from paragraph properties if present", function() {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -121,7 +121,10 @@ test("paragraph has indent hanging read from paragraph properties if present", f
 test("paragraph has no indent read from paragraph properties", function() {
     var paragraphXml = paragraphWithIndent({});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.deepEqual(paragraph.indent, undefined);
+    assert.deepEqual(paragraph.indent.left, null);
+    assert.deepEqual(paragraph.indent.right, null);
+    assert.deepEqual(paragraph.indent.firstLine, null);
+    assert.deepEqual(paragraph.indent.hanging, null);
 });
 
 function paragraphWithIndent(indentAttributes) {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -97,13 +97,13 @@ test("paragraph has justification read from paragraph properties if present", fu
 test("paragraph has indent left read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:left": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.left, "720");
+    assert.equal(paragraph.indent.start, "720");
 });
 
 test("paragraph has indent right read from paragraph properties if present", function() {
     var paragraphXml = paragraphWithIndent({"w:right": "720"});
     var paragraph = readXmlElementValue(paragraphXml);
-    assert.equal(paragraph.indent.right, "720");
+    assert.equal(paragraph.indent.end, "720");
 });
 
 test("paragraph has indent firstLine read from paragraph properties if present", function() {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -95,13 +95,25 @@ test("paragraph has justification read from paragraph properties if present", fu
 });
 
 test("paragraph indent", {
-    "paragraph has indent left read from paragraph properties if present": function() {
+    "when w:start is set then start indent is read from w:start": function() {
+        var paragraphXml = paragraphWithIndent({"w:start": "720", "w:left": "40"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.start, "720");
+    },
+    
+    "when w:start is not set then start indent is read from w:left": function() {
         var paragraphXml = paragraphWithIndent({"w:left": "720"});
         var paragraph = readXmlElementValue(paragraphXml);
         assert.equal(paragraph.indent.start, "720");
     },
 
-    "paragraph has indent right read from paragraph properties if present": function() {
+    "when w:end is set then end indent is read from w:end": function() {
+        var paragraphXml = paragraphWithIndent({"w:end": "720", "w:right": "40"});
+        var paragraph = readXmlElementValue(paragraphXml);
+        assert.equal(paragraph.indent.end, "720");
+    },
+
+    "when w:end is not set then end indent is read from w:right": function() {
         var paragraphXml = paragraphWithIndent({"w:right": "720"});
         var paragraph = readXmlElementValue(paragraphXml);
         assert.equal(paragraph.indent.end, "720");
@@ -122,8 +134,8 @@ test("paragraph indent", {
     "when indent attributes aren't set then indents are null": function() {
         var paragraphXml = paragraphWithIndent({});
         var paragraph = readXmlElementValue(paragraphXml);
-        assert.equal(paragraph.indent.left, null);
-        assert.equal(paragraph.indent.right, null);
+        assert.equal(paragraph.indent.start, null);
+        assert.equal(paragraph.indent.end, null);
         assert.equal(paragraph.indent.firstLine, null);
         assert.equal(paragraph.indent.hanging, null);
     }

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -107,7 +107,7 @@ indentProperties.forEach(function(property) {
         var propertiesXml = new XmlElement("w:pPr", {}, [indentXml]);
         var paragraphXml = new XmlElement("w:p", {}, [propertiesXml]);
         var paragraph = readXmlElementValue(paragraphXml);
-        assert.deepEqual(paragraph.indent[name], property.value[Object.keys(property.value)[0]]);
+        assert.deepEqual(paragraph.indent[property.name], property.value[Object.keys(property.value)[0]]);
     });
 });
 


### PR DESCRIPTION
Added support to parse Paragraph indents
![image](https://user-images.githubusercontent.com/7475401/29432741-c579b0f2-836a-11e7-8280-94148c41350d.png)

This was the end result of the #121 discussion.

~~Currently it is only available for the transform and is not translated to HTML. (This could be part 2)~~