### PR TITLE
Fix for #142 - warning - "An unrecognised element was ignored: v:rect"

### DIFF
--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -297,7 +297,8 @@ function BodyReader(options) {
         "wp:inline": readDrawingElement,
         "wp:anchor": readDrawingElement,
         "v:imagedata": readImageData,
-        "v:group": readChildElements
+        "v:group": readChildElements,
+        "v:rect": readChildElements
     };
     
     return {

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -1162,6 +1162,23 @@ test("text boxes have content appended after containing paragraph", function() {
     assert.deepEqual(result.value[1].styleId, "textbox-content");
 });
 
+test("output rectangle content as paragraph", function() {
+    var textbox = new XmlElement("w:pict", {}, [
+        new XmlElement("v:rect", {}, [
+            new XmlElement("v:textbox", {}, [
+                new XmlElement("w:txbxContent", {}, [
+                    paragraphWithStyleId("vrect-textbox-content")
+                ])
+            ])
+        ])
+    ]);
+    var paragraph = new XmlElement("w:p", {}, [
+        new XmlElement("w:r", {}, [textbox])
+    ]);
+    var result = readXmlElement(paragraph);
+    assert.deepEqual(result.value[1].styleId, "vrect-textbox-content");
+});
+
 test("mc:Fallback is used when mc:AlternateContent is read", function() {
     var styles = new Styles({"first": {name: "First"}, "second": {name: "Second"}}, {});
     var textbox = new XmlElement("mc:AlternateContent", {}, [


### PR DESCRIPTION
Add "v:rect" to available xml element readers that just parse it child.