### PR TITLE
feat: Add numbering attributes and find num by styleId

### DIFF
--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -186,12 +186,13 @@ function BodyReader(options) {
         },
         "w:pPr": function(element) {
             return readParagraphStyle(element).map(function(style) {
+                var styleId = element.firstOrEmpty("w:pStyle").attributes["w:val"];
                 return {
                     type: "paragraphProperties",
                     styleId: style.styleId,
                     styleName: style.name,
                     alignment: element.firstOrEmpty("w:jc").attributes["w:val"],
-                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering),
+                    numbering: readNumberingProperties(element.firstOrEmpty("w:numPr"), numbering, styleId),
                     indent: readParagraphIndent(element.firstOrEmpty("w:ind"))
                 };
             });
@@ -480,13 +481,16 @@ function BodyReader(options) {
 }
 
 
-function readNumberingProperties(element, numbering) {
+function readNumberingProperties(element, numbering, styleId) {
     var level = element.firstOrEmpty("w:ilvl").attributes["w:val"];
     var numId = element.firstOrEmpty("w:numId").attributes["w:val"];
-    if (level === undefined || numId === undefined) {
+    if (!numbering) {
+        return null;
+    }
+    if ((level === undefined || numId === undefined) && styleId === undefined) {
         return null;
     } else {
-        return numbering.findLevel(numId, level);
+        return numbering.findLevel(numId, level, styleId);
     }
 }
     

--- a/lib/docx/numbering-xml.js
+++ b/lib/docx/numbering-xml.js
@@ -2,12 +2,12 @@ exports.readNumberingXml = readNumberingXml;
 exports.Numbering = Numbering;
 exports.defaultNumbering = new Numbering({});
 
-function Numbering(nums) {
+function Numbering(nums, styleIdMap) {
     return {
-        findLevel: function(numId, level) {
-            var num = nums[numId];
+        findLevel: function(numId, level, styleId) {
+            var num = (nums[numId] && nums[numId][level]) || (styleIdMap && styleIdMap[styleId]);
             if (num) {
-                return num[level];
+                return num;
             } else {
                 return null;
             }
@@ -18,7 +18,8 @@ function Numbering(nums) {
 function readNumberingXml(root) {
     var abstractNums = readAbstractNums(root);
     var nums = readNums(root, abstractNums);
-    return new Numbering(nums);
+    var styleIdMap = createStyleIdMap(root, abstractNums);
+    return new Numbering(nums, styleIdMap);
 }
 
 function readAbstractNums(root) {
@@ -35,9 +36,14 @@ function readAbstractNum(element) {
     element.getElementsByTagName("w:lvl").forEach(function(levelElement) {
         var levelIndex = levelElement.attributes["w:ilvl"];
         var numFmt = levelElement.first("w:numFmt").attributes["w:val"];
+        var lvlText = levelElement.firstOrEmpty("w:lvlText").attributes["w:val"];
+        var pStyle = levelElement.firstOrEmpty("w:pStyle").attributes["w:val"];
         levels[levelIndex] = {
             isOrdered: numFmt !== "bullet",
-            level: levelIndex
+            level: levelIndex,
+            numFmt: numFmt,
+            lvlText: lvlText,
+            pStyle: pStyle
         };
     });
     return levels;
@@ -51,4 +57,16 @@ function readNums(root, abstractNums) {
         nums[id] = abstractNums[abstractNumId];
     });
     return nums;
+}
+
+function createStyleIdMap(root, abstractNums) {
+    var map = {};
+    Object.keys(abstractNums).forEach(function(numKey) {
+        Object.keys(abstractNums[numKey]).forEach(function(k) {
+            if (abstractNums[numKey][k].pStyle) {
+                map[abstractNums[numKey][k].pStyle] = abstractNums[numKey][k];
+            }
+        });
+    });
+    return map;
 }

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -174,6 +174,14 @@ test("numbering properties are converted to numbering at specified level", funct
     assert.deepEqual(numberingLevel, {level: "1", isOrdered: true});
 });
 
+test("numbering properties are converted to numbering at specified styleId", function() {
+    var numberingPropertiesXml = new XmlElement("w:pStyle", {"w:val": "a"});
+    
+    var numbering = new Numbering({"42": {"1": {isOrdered: true, level: "1", pStyle: "a"}}}, {a: {isOrdered: true, level: "1", pStyle: "a"}});
+    var numberingLevel = _readNumberingProperties(numberingPropertiesXml, numbering, "a");
+    assert.deepEqual(numberingLevel, {level: "1", isOrdered: true, pStyle: "a"});
+});
+
 test("numbering properties are ignored if w:ilvl is missing", function() {
     var numberingPropertiesXml = new XmlElement("w:numPr", {}, [
         new XmlElement("w:numId", {"w:val": "42"})
@@ -1265,3 +1273,4 @@ function imageRelationship(relationshipId, target) {
         type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
     };
 }
+


### PR DESCRIPTION
Hi. At first, thanks for your great library.
I added some attributes to `numbering` object.
Because we need `lvlText` attribute to convert `auto numbering` text with `transformDocument` option.

And I ran into a rare case document.

[referenced_by_styleid.docx](https://github.com/mwilliamson/mammoth.js/files/2659853/referenced_by_styleid.docx)

This docx include styleId in `numbering.xml` like following.

- numbering.xml
``` xml
            <w:start w:val="1" />
            <w:numFmt w:val="decimal" />
            <w:pStyle w:val="a" />
            <w:lvlText w:val="第%1条" />
            <w:lvlJc w:val="left" />
            <w:pPr>
                <w:tabs>
                    <w:tab w:val="num" w:pos="720" />
                </w:tabs>
                <w:ind w:left="420" w:hanging="420" />
            </w:pPr>
```

- document.xml
``` xml
       <w:p w:rsidR="00EF06DD" w:rsidP="00EF06DD" w:rsidRDefault="00EF06DD" w14:paraId="6F269F4D" w14:textId="77777777">
            <w:pPr>
                <w:pStyle w:val="a" />
                <w:spacing w:before="180" w:after="180" />
            </w:pPr>
            <w:r>
                <w:rPr>
                    <w:rFonts w:hint="eastAsia" />
                </w:rPr>
                <w:t>目的</w:t>
            </w:r>
        </w:p>
```

I guess this doc numbering attributes is related by only styleId.
So I added function to find num attributes by `styleId` when num is not be found by `numId`.