### PR TITLE
Feat: add support for image title

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -151,6 +151,7 @@ function Image(options) {
     return {
         type: types.image,
         read: options.readImage,
+        title: options.title,
         altText: options.altText,
         contentType: options.contentType
     };

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -423,8 +423,7 @@ function BodyReader(options) {
 
     function readBlip(element, blip) {
         var properties = element.first("wp:docPr").attributes;
-        var altText = isBlank(properties.descr) ? properties.title : properties.descr;
-        return readImage(findBlipImageFile(blip), altText);
+        return readImage(findBlipImageFile(blip), properties.descr, properties.title);
     }
 
     function isBlank(value) {
@@ -465,12 +464,13 @@ function BodyReader(options) {
         };
     }
 
-    function readImage(imageFile, altText) {
+    function readImage(imageFile, altText, title) {
         var contentType = contentTypes.findContentType(imageFile.path);
 
         var image = documents.Image({
             readImage: imageFile.read,
-            altText: altText,
+            altText: isBlank(altText) ? title : altText,
+            title: title,
             contentType: contentType
         });
         var warnings = supportedImageTypes[contentType] ?

--- a/test/docx/body-reader.tests.js
+++ b/test/docx/body-reader.tests.js
@@ -871,13 +871,15 @@ test("when v:imagedata element has no relationship ID then it is ignored with wa
 test("can read inline pictures", function() {
     var drawing = createInlineImage({
         blip: createEmbeddedBlip(IMAGE_RELATIONSHIP_ID),
-        description: "It's a hat"
+        description: "It's a hat",
+        title: "Sombrero"
     });
 
     var result = readEmbeddedImage(drawing);
 
     return promiseThat(result, isSuccess(contains(isImage({
         altText: "It's a hat",
+        title: "Sombrero",
         contentType: "image/png",
         buffer: IMAGE_BUFFER
     }))));
@@ -892,6 +894,7 @@ test("alt text title is used if alt text description is missing", function() {
     var result = readEmbeddedImage(drawing);
 
     return promiseThat(result, isSuccess(contains(isImage({
+        title: "It's a hat",
         altText: "It's a hat"
     }))));
 });
@@ -906,7 +909,8 @@ test("alt text title is used if alt text description is blank", function() {
     var result = readEmbeddedImage(drawing);
 
     return promiseThat(result, isSuccess(contains(isImage({
-        altText: "It's a hat"
+        altText: "It's a hat",
+        title: "It's a hat"
     }))));
 });
 
@@ -920,7 +924,8 @@ test("alt text description is preferred to alt text title", function() {
     var result = readEmbeddedImage(drawing);
 
     return promiseThat(result, isSuccess(contains(isImage({
-        altText: "It's a hat"
+        altText: "It's a hat",
+        title: "hat"
     }))));
 });
 


### PR DESCRIPTION
- added support to retain the image title
- the `Image` node contains the `title` from the original image title and the `altText` from the image description.
- it is backward compatible such as if the description is missing, the title is used as alt text.