### PR TITLE
Add support for preserving colors and fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /static/jszip
 /mammoth.browser.js
 /mammoth.browser.min.js
+.idea

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ and ignoring other details.
 For instance,
 Mammoth converts any paragraph with the style `Heading 1` to `h1` elements,
 rather than attempting to exactly copy the styling (font, text size, colour, etc.) of the heading.
+Note that you can optionally preserve text colour and highlight through a `<mark>` tag.
 
 There's a large mismatch between the structure used by .docx and the structure of HTML,
 meaning that the conversion is unlikely to be perfect for more complicated documents.
@@ -294,6 +295,36 @@ var options = {
     styleMap: [
         "strike => del"
     ]
+};
+mammoth.convertToHtml({path: "path/to/document.docx"}, options);
+```
+
+#### Colors
+
+Text foreground and background colors can be optionally wrapped in `<mark>` 
+tags to preserve colors.
+
+```javascript
+var mammoth = require("mammoth");
+
+var options = {
+    preserveColors: true // preserveColours also works
+};
+mammoth.convertToHtml({path: "path/to/document.docx"}, options);
+```
+
+#### Fonts
+
+Fonts can be optionally wrapped in `<font>` tags. Although the `<font>` tag is 
+deprecated, it may provide useful in some conversions. Typeface is specified
+through a `style="font-family: X"` attribute in case the browser does not 
+support the `face` attribute.
+
+```javascript
+var mammoth = require("mammoth");
+
+var options = {
+    preserveColors: true
 };
 mammoth.convertToHtml({path: "path/to/document.docx"}, options);
 ```

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -39,6 +39,10 @@ function DocumentConversion(options, comments) {
 
     var styleMap = options.styleMap || [];
 
+    var preserveColors = options.preserveColors || options.preserveColours;
+
+    var preserveFonts = options.preserveFonts;
+
     function convertToHtml(document) {
         var messages = [];
 
@@ -127,6 +131,23 @@ function DocumentConversion(options, comments) {
             return convertElements(run.children, messages, options);
         };
         var paths = [];
+
+        if (preserveColors && (run.color || run.highlight)) {
+            var styleProps = [];
+            if (run.color) {
+                styleProps.push("color: " + formatColor(run.color));
+            }
+            if (run.highlight) {
+                styleProps.push("background-color: " + formatColor(run.highlight));
+            } else if (preserveColors) {
+                styleProps.push("background-color: inherit");
+            }
+            paths.push(htmlPaths.element("mark", {style: styleProps.join('; ')}, {fresh: false}));
+        }
+        if (run.font && preserveFonts) {
+            paths.push(htmlPaths.element("font", {style: "font-family: " + run.font}));
+        }
+
         if (run.isSmallCaps) {
             paths.push(findHtmlPathForRunProperty("smallCaps"));
         }
@@ -151,6 +172,7 @@ function DocumentConversion(options, comments) {
         if (run.isBold) {
             paths.push(findHtmlPathForRunProperty("bold", "strong"));
         }
+
         var stylePath = htmlPaths.empty;
         var style = findStyle(run);
         if (style) {
@@ -165,6 +187,13 @@ function DocumentConversion(options, comments) {
         });
 
         return nodes();
+    }
+
+    function formatColor(maybeHex) {
+        if (/^[0-9A-F]{6,8}$/.test(maybeHex)) {
+            return '#' + maybeHex;
+        }
+        return maybeHex;
     }
 
     function findHtmlPathForRunProperty(elementType, defaultTagName) {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -63,7 +63,9 @@ function Run(children, properties) {
         isSmallCaps: properties.isSmallCaps,
         verticalAlignment: properties.verticalAlignment || verticalAlignment.baseline,
         font: properties.font || null,
-        fontSize: properties.fontSize || null
+        fontSize: properties.fontSize || null,
+        color: properties.color || null,
+        highlight: properties.highlight || null
     };
 }
 

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -75,7 +75,9 @@ function BodyReader(options) {
                 isItalic: readBooleanElement(element.first("w:i")),
                 isStrikethrough: readBooleanElement(element.first("w:strike")),
                 isAllCaps: readBooleanElement(element.first("w:caps")),
-                isSmallCaps: readBooleanElement(element.first("w:smallCaps"))
+                isSmallCaps: readBooleanElement(element.first("w:smallCaps")),
+                color: element.firstOrEmpty("w:color").attributes["w:val"],
+                highlight: element.firstOrEmpty("w:highlight").attributes["w:val"]
             };
         });
     }

--- a/test/document-to-html.tests.js
+++ b/test/document-to-html.tests.js
@@ -800,6 +800,46 @@ test('long documents do not cause stack overflow', function() {
     });
 });
 
+test('hex text color in <mark> tags', function() {
+    var run = runOfText("0000FF.", {color: "0000FF"});
+    var converter = new DocumentConverter({
+        preserveColors: true
+    });
+    return converter.convertToHtml(run).then(function(result) {
+        assert.equal(result.value, "<mark style=\"color: #0000FF; background-color: inherit\">0000FF.</mark>");
+    });
+});
+
+test('named color in <mark> tags', function() {
+    var run = runOfText("Blue.", {color: "blue"});
+    var converter = new DocumentConverter({
+        preserveColors: true
+    });
+    return converter.convertToHtml(run).then(function(result) {
+        assert.equal(result.value, "<mark style=\"color: blue; background-color: inherit\">Blue.</mark>");
+    });
+});
+
+test('background color in <mark> tags', function() {
+    var run = runOfText("Yellow Highlighted.", {highlight: "yellow"});
+    var converter = new DocumentConverter({
+        preserveColors: true
+    });
+    return converter.convertToHtml(run).then(function(result) {
+        assert.equal(result.value, "<mark style=\"background-color: yellow\">Yellow Highlighted.</mark>");
+    });
+});
+
+test('font in in <font> tags', function() {
+    var run = runOfText("Times New Roman.", {font: "Times New Roman"});
+    var converter = new DocumentConverter({
+        preserveFonts: true
+    });
+    return converter.convertToHtml(run).then(function(result) {
+        assert.equal(result.value, "<font style=\"font-family: Times New Roman\">Times New Roman.</font>");
+    });
+});
+
 function paragraphOfText(text, styleId, styleName) {
     var run = runOfText(text);
     return new documents.Paragraph([run], {


### PR DESCRIPTION
I need to preserve colors because it provides semantic meaning in my use case. The html `<mark>` element was specifically designed to represent "marked" text. By default browsers apply a background color of yellow to `<mark>` elements.

This PR adds a style attribute (with `color` and `background-color`) to make `<mark>` elements the color and highlight specified in the word document.

The README.md has been updated to document the new functionality. Unit tests have been added to validate the behavior.

I saw other GitHub issues requesting to preserve fonts, so I threw in that ability. Although the `<font>` tag is deprecated, it may provide useful in some conversions. Typeface is specified through a `style="font-family: X"` attribute in case the browser does not support the `face` attribute.