### PR TITLE
Preserve line breaks when extracting raw text.

### DIFF
--- a/lib/raw-text.js
+++ b/lib/raw-text.js
@@ -5,6 +5,8 @@ function convertElementToRawText(element) {
         return element.value;
     } else if (element.type === documents.types.tab) {
         return "\t";
+    } else if (element.type === "break") {
+        return "\n"
     } else {
         var tail = element.type === "paragraph" ? "\n\n" : "";
         return (element.children || []).map(convertElementToRawText).join("") + tail;


### PR DESCRIPTION
To fix https://github.com/mwilliamson/mammoth.js/issues/252

Raw text output makes little sense with the line breaks removed. 

If paragraph line breaks are extracted, shouldn't normal line breaks also be extracted?