### PR TITLE
feat: add wildcard * class to ignore classes when matching parent elements

### DIFF
--- a/lib/style-reader.js
+++ b/lib/style-reader.js
@@ -240,7 +240,10 @@ function htmlPathRule() {
     ).map(function(tagName, classNames, fresh, separator) {
         var attributes = {};
         var options = {};
-        if (classNames.length > 0) {
+        var isWildcardClass = (classNames.length === 1 && classNames[0] === "*");
+        if (isWildcardClass) {
+            options.ignoreClass = true;
+        } else if (classNames.length > 0) {
             attributes["class"] = classNames.join(" ");
         }
         if (fresh) {
@@ -281,6 +284,8 @@ var stringRule = lop.rules.then(
     decodeEscapeSequences
 );
 
+var wildcardRule = lop.rules.tokenOfType("wildcard");
+
 var escapeSequences = {
     "n": "\n",
     "r": "\r",
@@ -296,7 +301,7 @@ function decodeEscapeSequences(value) {
 var classRule = lop.rules.sequence(
     lop.rules.tokenOfType("dot"),
     lop.rules.sequence.cut(),
-    lop.rules.sequence.capture(identifierRule)
+    lop.rules.sequence.capture(lop.rules.firstOf('wildcard or identifier', wildcardRule, identifierRule))
 ).head();
 
 function parseString(rule, string) {

--- a/lib/styles/html-paths.js
+++ b/lib/styles/html-paths.js
@@ -53,10 +53,11 @@ function Element(tagName, attributes, options) {
     this.attributes = attributes || {};
     this.fresh = options.fresh;
     this.separator = options.separator;
+    this.ignoreClass = options.ignoreClass;
 }
 
 Element.prototype.matchesElement = function(element) {
-    return this.tagNames[element.tagName] && _.isEqual(this.attributes || {}, element.attributes || {});
+    return this.tagNames[element.tagName] && (this.ignoreClass || _.isEqual(this.attributes || {}, element.attributes || {}));
 };
 
 Element.prototype.wrap = function wrap(generateNodes) {

--- a/lib/styles/parser/tokeniser.js
+++ b/lib/styles/parser/tokeniser.js
@@ -24,7 +24,8 @@ function tokenise(string) {
         {name: "unterminated-string", regex: new RegExp(stringPrefix)},
         {name: "integer", regex: /([0-9]+)/},
         {name: "choice", regex: /\|/},
-        {name: "bang", regex: /(!)/}
+        {name: "bang", regex: /(!)/},
+        {name: "wildcard", regex: /(\*)/}
     ]);
     return tokeniser.tokenise(string);
 }

--- a/test/style-reader.tests.js
+++ b/test/style-reader.tests.js
@@ -54,6 +54,13 @@ test('styleReader.readHtmlPath', {
         assertHtmlPath("p.tip.help", expected);
     },
 
+    'reads wildcard class on element': function() {
+        var expected = htmlPaths.elements([
+            htmlPaths.element("p", {}, {"ignoreClass": true})
+        ]);
+        assertHtmlPath("p.*", expected);
+    },
+
     'reads when element must be fresh': function() {
         var expected = htmlPaths.elements([
             htmlPaths.element("p", {}, {"fresh": true})


### PR DESCRIPTION
Fixes #308 by introducing a wildcard class selector for html paths. When a wildcard is used, a new element option `ignoreClass` is enabled which bypasses checking attribute equality in `Element.prototype.matchesElement`.
I'm new to `lop`, so I know the rule I've setup has a hole which would count * as a regular class if * is used in conjunction with another class. Would appreciate some guidance on how I would go about preventing that.

Thanks for this awesome project!