### PR TITLE
Parse headers

### DIFF
--- a/lib/docx/document-xml-reader.js
+++ b/lib/docx/document-xml-reader.js
@@ -6,10 +6,17 @@ var Result = require("../results").Result;
 
 function DocumentXmlReader(options) {
     var bodyReader = options.bodyReader;
-    
-    function convertXmlToDocument(element) {
-        var body = element.first("w:body");
-        
+
+    function convertXmlToDocument(element, firstTag) {
+        if (firstTag === undefined){
+            firstTag = "w:body";
+        }
+        var body = element.first(firstTag);
+
+        if (body === undefined && element.name === firstTag) {
+            body = element;
+        }
+
         var result = bodyReader.readXmlElements(body.children)
             .map(function(children) {
                 return new documents.Document(children, {
@@ -19,7 +26,7 @@ function DocumentXmlReader(options) {
             });
         return new Result(result.value, result.messages);
     }
-    
+
     return {
         convertXmlToDocument: convertXmlToDocument
     };

--- a/lib/docx/docx-reader.js
+++ b/lib/docx/docx-reader.js
@@ -58,6 +58,18 @@ function read(docxFile, input) {
                 } else {
                     return new Result([]);
                 }
+            }),
+            header: readXmlFileWithBody(result.partPaths.header, result, function(bodyReader, xml) {
+                if (xml) {
+                    var reader = new DocumentXmlReader({
+                        bodyReader: bodyReader,
+                        notes: new Result([]),
+                        comments: new Result([])
+                    });
+                    return reader.convertXmlToDocument(xml, "w:hdr");
+                } else {
+                    return new Result([]);
+                }
             })
         };
     }).also(function(result) {
@@ -77,7 +89,10 @@ function read(docxFile, input) {
                         notes: notes,
                         comments: comments
                     });
-                    return reader.convertXmlToDocument(xml);
+                    return new Result({
+                        "document": reader.convertXmlToDocument(xml),
+                        "header": result.header
+                    });
                 });
             });
         });
@@ -119,7 +134,8 @@ function findPartPaths(docxFile) {
                 endnotes: findPartRelatedToMainDocument("endnotes"),
                 footnotes: findPartRelatedToMainDocument("footnotes"),
                 numbering: findPartRelatedToMainDocument("numbering"),
-                styles: findPartRelatedToMainDocument("styles")
+                styles: findPartRelatedToMainDocument("styles"),
+                header: findPartRelatedToMainDocument("header1")
             };
         });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,14 @@ function convert(input, options) {
                     return documentResult.map(options.transformDocument);
                 })
                 .then(function(documentResult) {
-                    return convertDocumentToHtml(documentResult, options);
+                    // console.log(documentResult);
+                    if (options.returnPart == "document"){
+                        return convertDocumentToHtml(documentResult.value.document, options);
+                    } else if (options.returnPart == "header"){
+                        return convertDocumentToHtml(documentResult.value.header, options);
+                    } else {
+                        return convertDocumentToHtml(documentResult.document, options);
+                    }
                 });
         });
 }

--- a/lib/options-reader.js
+++ b/lib/options-reader.js
@@ -22,22 +22,22 @@ var defaultStyleMap = exports._defaultStyleMap = [
     "p[style-name='heading 4'] => h4:fresh",
     "p[style-name='heading 5'] => h5:fresh",
     "p[style-name='heading 6'] => h6:fresh",
-    
+
     "r[style-name='Strong'] => strong",
-    
+
     "p[style-name='footnote text'] => p:fresh",
     "r[style-name='footnote reference'] =>",
     "p[style-name='endnote text'] => p:fresh",
     "r[style-name='endnote reference'] =>",
     "p[style-name='annotation text'] => p:fresh",
     "r[style-name='annotation reference'] =>",
-    
+
     // LibreOffice
     "p[style-name='Footnote'] => p:fresh",
     "r[style-name='Footnote anchor'] =>",
     "p[style-name='Endnote'] => p:fresh",
     "r[style-name='Endnote anchor'] =>",
-    
+
     "p:unordered-list(1) => ul > li:fresh",
     "p:unordered-list(2) => ul|ol > li > ul > li:fresh",
     "p:unordered-list(3) => ul|ol > li > ul|ol > li > ul > li:fresh",
@@ -48,16 +48,17 @@ var defaultStyleMap = exports._defaultStyleMap = [
     "p:ordered-list(3) => ul|ol > li > ul|ol > li > ol > li:fresh",
     "p:ordered-list(4) => ul|ol > li > ul|ol > li > ul|ol > li > ol > li:fresh",
     "p:ordered-list(5) => ul|ol > li > ul|ol > li > ul|ol > li > ul|ol > li > ol > li:fresh",
-    
+
     "r[style-name='Hyperlink'] =>",
-    
+
     "p[style-name='Normal'] => p:fresh"
 ];
 
 var standardOptions = exports._standardOptions = {
     transformDocument: identity,
     includeDefaultStyleMap: true,
-    includeEmbeddedStyleMap: true
+    includeEmbeddedStyleMap: true,
+    returnPart: "document"
 };
 
 function readOptions(options) {


### PR DESCRIPTION
> In general, pull requests are not currently accepted.
> 
> Please instead submit an issue if you find a bug or would like to request a feature.


well, I didn't see that before.

Anyway, my additions are a bit of a mess.

But it allows for the exporting of doc headers along with the body.

I know it's been said before that support for headers isn't going to happen. However, I'm using this package to convert a doc into an easier to part format. And having the headers is a huge boon as I can now extract the info trapped there.

I'd love if a better implementation of something like this was done. As it would be fantastic to be able to at least access the header, it doesn't have to be a default, and probably shouldn't. As said before, there's no obvious or standard way to do a header/footer in HTML.

It shouldn't cause any breakage....

I wasn't able to run the tests. They didn't fail, they didn't run...