### PR TITLE
Switch from bluebird to native promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
 
   "globals": {
     "Buffer": false,
+    "Promise": true,
     "console": true,
     "exports": true,
     "module": true,

--- a/browser/docx/files.js
+++ b/browser/docx/files.js
@@ -5,7 +5,7 @@ exports.Files = Files;
 
 function Files() {
     function read(uri) {
-        return promises.reject(new Error("could not open external image: '" + uri + "'\ncannot open linked files from a web browser"));
+        return Promise.reject(new Error("could not open external image: '" + uri + "'\ncannot open linked files from a web browser"));
     }
     
     return {

--- a/browser/unzip.js
+++ b/browser/unzip.js
@@ -5,8 +5,8 @@ exports.openZip = openZip;
 
 function openZip(options) {
     if (options.arrayBuffer) {
-        return promises.resolve(zipfile.openArrayBuffer(options.arrayBuffer));
+        return Promise.resolve(zipfile.openArrayBuffer(options.arrayBuffer));
     } else {
-        return promises.reject(new Error("Could not find file in options"));
+        return Promise.reject(new Error("Could not find file in options"));
     }
 }

--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -195,7 +195,7 @@ function DocumentConversion(options, comments) {
         return function(image, messages) {
             return promises.attempt(function() {
                 return convertImage(image, messages);
-            }).caught(function(error) {
+            }).catch(function(error) {
                 messages.push(results.error(error));
                 return [];
             });

--- a/lib/docx/files.js
+++ b/lib/docx/files.js
@@ -14,9 +14,9 @@ exports.uriToPath = uriToPath;
 function Files(base) {
     function read(uri, encoding) {
         return resolveUri(uri).then(function(path) {
-            return readFile(path, encoding).caught(function(error) {
+            return readFile(path, encoding).catch(function(error) {
                 var message = "could not open external image: '" + uri + "' (document directory: '" + base + "')\n" + error.message;
-                return promises.reject(new Error(message));
+                return Promise.reject(new Error(message));
             });
         });
     }
@@ -24,11 +24,11 @@ function Files(base) {
     function resolveUri(uri) {
         var path = uriToPath(uri);
         if (isAbsolutePath(path)) {
-            return promises.resolve(path);
+            return Promise.resolve(path);
         } else if (base) {
-            return promises.resolve(resolvePath(base, path));
+            return Promise.resolve(resolvePath(base, path));
         } else {
-            return promises.reject(new Error("could not find external image '" + uri + "', path of input document is unknown"));
+            return Promise.reject(new Error("could not find external image '" + uri + "', path of input document is unknown"));
         }
     }
     

--- a/lib/docx/office-xml-reader.js
+++ b/lib/docx/office-xml-reader.js
@@ -1,6 +1,5 @@
 var _ = require("underscore");
 
-var promises = require("../promises");
 var xml = require("../xml");
 
 
@@ -34,7 +33,7 @@ function readXmlFromZipFile(docxFile, path) {
             .then(stripUtf8Bom)
             .then(read);
     } else {
-        return promises.resolve(null);
+        return Promise.resolve(null);
     }
 }
 

--- a/lib/docx/style-map.js
+++ b/lib/docx/style-map.js
@@ -1,6 +1,5 @@
 var _ = require("underscore");
 
-var promises = require("../promises");
 var xml = require("../xml");
 
 exports.writeStyleMap = writeStyleMap;
@@ -70,6 +69,6 @@ function readStyleMap(docxFile) {
     if (docxFile.exists(styleMapPath)) {
         return docxFile.read(styleMapPath, "utf8");
     } else {
-        return promises.resolve(null);
+        return Promise.resolve(null);
     }
 }

--- a/lib/images.js
+++ b/lib/images.js
@@ -1,13 +1,12 @@
 var _ = require("underscore");
 
-var promises = require("./promises");
 var Html = require("./html");
 
 exports.imgElement = imgElement;
 
 function imgElement(func) {
     return function(element, messages) {
-        return promises.when(func(element)).then(function(result) {
+        return Promise.resolve(func(element)).then(function(result) {
             var attributes = {};
             if (element.altText) {
                 attributes.alt = element.altText;

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,7 +56,7 @@ function readStyleMap(styleMapPath) {
     if (styleMapPath) {
         return promises.nfcall(fs.readFile, styleMapPath, "utf8");
     } else {
-        return promises.resolve(null);
+        return Promise.resolve(null);
     }
 }
 

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -1,35 +1,9 @@
 var _ = require("underscore");
-var bluebird = require("bluebird/js/release/promise")();
 
-exports.defer = defer;
-exports.when = bluebird.resolve;
-exports.resolve = bluebird.resolve;
-exports.all = bluebird.all;
-exports.props = bluebird.props;
-exports.reject = bluebird.reject;
-exports.promisify = bluebird.promisify;
-exports.mapSeries = bluebird.mapSeries;
-exports.attempt = bluebird.attempt;
-
-exports.nfcall = function(func) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var promisedFunc = bluebird.promisify(func);
-    return promisedFunc.apply(null, args);
-};
-
-bluebird.prototype.fail = bluebird.prototype.caught;
-
-bluebird.prototype.also = function(func) {
-    return this.then(function(value) {
-        var returnValue = _.extend({}, value, func(value));
-        return bluebird.props(returnValue);
-    });
-};
-
-function defer() {
+exports.defer = function() {
     var resolve;
     var reject;
-    var promise = new bluebird.Promise(function(resolveArg, rejectArg) {
+    var promise = new Promise(function(resolveArg, rejectArg) {
         resolve = resolveArg;
         reject = rejectArg;
     });
@@ -39,4 +13,99 @@ function defer() {
         reject: reject,
         promise: promise
     };
-}
+};
+
+exports.props = function(obj) {
+    var keys = Object.keys(obj);
+    var promises = keys.map(function(key){
+        return obj[key];
+    });
+
+    return Promise.all(promises).then(function(results) {
+        return results.reduce(function(acc, result, index) {
+            acc[keys[index]] = result;
+            return acc;
+        }, {});
+    });
+};
+
+exports.promisify = function(nodeStyleFunction) {
+    return function() {
+        var args = Array.prototype.slice.call(arguments);
+        return new Promise(function(resolve, reject) {
+            args.push(function(error, result) {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(result);
+                }
+            });
+            nodeStyleFunction.apply(this, args);
+        });
+    };
+};
+
+exports.mapSeries = function(arr, iterator) {
+    var results = [];
+    var promise = Promise.resolve();
+
+    arr.forEach(function(item, index) {
+        promise = promise.then(function() {
+            return iterator(item, index);
+        }).then(function(result) {
+            results.push(result);
+        });
+    });
+
+    return promise.then(function() {
+        return results;
+    });
+};
+
+exports.attempt = function(fn) {
+    return new Promise(function(resolve, reject) {
+        try {
+            // Resolve with the return value of the function
+            resolve(fn());
+        } catch (error) {
+            // If an error is thrown, reject the promise
+            reject(error);
+        }
+    });
+};
+
+exports.nfcall = function(func) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var promisedFunc = exports.promisify(func);
+    return promisedFunc.apply(null, args);
+};
+
+// eslint-disable-next-line no-extend-native
+Promise.prototype.also = function(func) {
+    return this.then(function(value) {
+        var returnValue = _.extend({}, value, func(value));
+        return exports.props(returnValue);
+    });
+};
+
+// eslint-disable-next-line no-extend-native
+Promise.prototype.tap = function(fn) {
+    return this.then(function(value){
+        var result = fn(value);
+        // If the result is a promise, wait for it before proceeding
+        return result instanceof Promise ? result.then(function(){
+            return value;
+        }) : value;
+    });
+};
+
+// eslint-disable-next-line no-extend-native
+Promise.prototype.done = function(onFulfilled, onRejected) {
+    this.then(onFulfilled, onRejected)
+        .catch(function(error) {
+            // eslint-disable-next-line no-undef
+            setTimeout(function() {
+                throw error;
+            }, 0);
+        });
+};

--- a/lib/unzip.js
+++ b/lib/unzip.js
@@ -11,10 +11,10 @@ function openZip(options) {
     if (options.path) {
         return readFile(options.path).then(zipfile.openArrayBuffer);
     } else if (options.buffer) {
-        return promises.resolve(zipfile.openArrayBuffer(options.buffer));
+        return Promise.resolve(zipfile.openArrayBuffer(options.buffer));
     } else if (options.file) {
-        return promises.resolve(options.file);
+        return Promise.resolve(options.file);
     } else {
-        return promises.reject(new Error("Could not find file in options"));
+        return Promise.reject(new Error("Could not find file in options"));
     }
 }

--- a/lib/xml/reader.js
+++ b/lib/xml/reader.js
@@ -1,4 +1,3 @@
-var promises = require("../promises");
 var _ = require("underscore");
 
 var xmldom = require("./xmldom");
@@ -15,11 +14,11 @@ function readString(xmlString, namespaceMap) {
     try {
         var document = xmldom.parseFromString(xmlString, "text/xml");
     } catch (error) {
-        return promises.reject(error);
+        return Promise.reject(error);
     }
 
     if (document.documentElement.tagName === "parsererror") {
-        return promises.resolve(new Error(document.documentElement.textContent));
+        return Promise.resolve(new Error(document.documentElement.textContent));
     }
 
     function convertNode(node) {
@@ -65,5 +64,5 @@ function readString(xmlString, namespaceMap) {
         }
     }
 
-    return promises.resolve(convertNode(document.documentElement));
+    return Promise.resolve(convertNode(document.documentElement));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "mammoth",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mammoth",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
         "argparse": "~1.0.3",
         "base64-js": "^1.5.1",
-        "bluebird": "~3.4.0",
         "dingbat-to-unicode": "^1.0.1",
         "jszip": "^3.7.1",
         "lop": "^0.4.1",
@@ -296,7 +295,8 @@
     "node_modules/bluebird": {
       "version": "3.4.7",
       "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.11.6",
@@ -3325,7 +3325,8 @@
     "bluebird": {
       "version": "3.4.7",
       "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@xmldom/xmldom": "^0.8.6",
     "argparse": "~1.0.3",
     "base64-js": "^1.5.1",
-    "bluebird": "~3.4.0",
     "dingbat-to-unicode": "^1.0.1",
     "jszip": "^3.7.1",
     "lop": "^0.4.1",

--- a/test/document-to-html.tests.js
+++ b/test/document-to-html.tests.js
@@ -1,5 +1,4 @@
 var assert = require("assert");
-var promises = require("../lib/promises");
 
 var documents = require("../lib/documents");
 var documentToHtml = require("../lib/document-to-html");
@@ -717,7 +716,7 @@ test('images are written with data URIs', function() {
     var imageBuffer = new Buffer("Not an image at all!");
     var image = new documents.Image({
         readImage: function(encoding) {
-            return promises.when(imageBuffer.toString(encoding));
+            return Promise.resolve(imageBuffer.toString(encoding));
         },
         contentType: "image/png"
     });
@@ -731,7 +730,7 @@ test('images have alt attribute if available', function() {
     var imageBuffer = new Buffer("Not an image at all!");
     var image = new documents.Image({
         readImage: function() {
-            return promises.when(imageBuffer);
+            return Promise.resolve(imageBuffer);
         },
         altText: "It's a hat"
     });
@@ -749,7 +748,7 @@ test('can add custom handler for images', function() {
     var imageBuffer = new Buffer("Not an image at all!");
     var image = new documents.Image({
         readImage: function(encoding) {
-            return promises.when(imageBuffer.toString(encoding));
+            return Promise.resolve(imageBuffer.toString(encoding));
         },
         contentType: "image/png"
     });
@@ -769,7 +768,7 @@ test('when custom image handler throws error then error is stored in error messa
     var error = new Error("Failed to convert image");
     var image = new documents.Image({
         readImage: function(encoding) {
-            return promises.when(new Buffer().toString(encoding));
+            return Promise.resolve(new Buffer().toString(encoding));
         },
         contentType: "image/png"
     });

--- a/test/images.tests.js
+++ b/test/images.tests.js
@@ -8,7 +8,6 @@ var hasProperties = hamjest.hasProperties;
 
 var mammoth = require("../");
 var documents = require("../lib/documents");
-var promises = require("../lib/promises");
 
 var test = require("./test")(module);
 
@@ -22,7 +21,7 @@ test('mammoth.images.dataUri() encodes images in base64', function() {
     var imageBuffer = new Buffer("abc");
     var image = new documents.Image({
         readImage: function(encoding) {
-            return promises.when(imageBuffer.toString(encoding));
+            return Promise.resolve(imageBuffer.toString(encoding));
         },
         contentType: "image/jpeg"
     });
@@ -40,7 +39,7 @@ test('mammoth.images.imgElement()', {
         var imageBuffer = new Buffer("abc");
         var image = new documents.Image({
             readImage: function(encoding) {
-                return promises.when(imageBuffer.toString(encoding));
+                return Promise.resolve(imageBuffer.toString(encoding));
             },
             contentType: "image/jpeg"
         });
@@ -64,7 +63,7 @@ test('mammoth.images.imgElement()', {
         var imageBuffer = new Buffer("abc");
         var image = new documents.Image({
             readImage: function(encoding) {
-                return promises.when(imageBuffer.toString(encoding));
+                return Promise.resolve(imageBuffer.toString(encoding));
             },
             contentType: "image/jpeg",
             altText: "<alt>"
@@ -89,7 +88,7 @@ test('mammoth.images.imgElement()', {
         var imageBuffer = new Buffer("abc");
         var image = new documents.Image({
             readImage: function(encoding) {
-                return promises.when(imageBuffer.toString(encoding));
+                return Promise.resolve(imageBuffer.toString(encoding));
             },
             contentType: "image/jpeg",
             altText: "<alt>"

--- a/test/testing.js
+++ b/test/testing.js
@@ -37,17 +37,17 @@ function createFakeFiles(files) {
 
 function createRead(files) {
     function read(path, encoding) {
-        return promises.when(files[path], function(buffer) {
+        return Promise.resolve(files[path], function(buffer) {
             if (_.isString(buffer)) {
                 buffer = new Buffer(buffer);
             }
 
             if (!Buffer.isBuffer(buffer)) {
-                return promises.reject(new Error("file was not a buffer"));
+                return Promise.reject(new Error("file was not a buffer"));
             } else if (encoding) {
-                return promises.when(buffer.toString(encoding));
+                return Promise.resolve(buffer.toString(encoding));
             } else {
-                return promises.when(buffer.buffer);
+                return Promise.resolve(buffer.buffer);
             }
         });
     }


### PR DESCRIPTION
Firstly, thanks for the great library!

Forgive the unsolicited PR, but I ran into an issue using mammoth on CloudFlare workers. The runtime does not allow runtime compilation of JS (essentially eval) for security reasons, and bluebird (which mammoth uses) does this as an optimisation.

This PR switches mammoth to use native promises. The tests all pass but obviously there could be some bugs introduced that are not covered by the suite. Also in an ideal world we wouldn't want to pollute the promise prototype, but I was trying to keep the changes as small as possible.

Not expecting you to merge it, but might be useful to others if they hit the same bug!

Thanks again.