### PR TITLE
ci: Integrate vet for scanning OSS components during PR

### DIFF
--- a/.github/vet/policy.yml
+++ b/.github/vet/policy.yml
@@ -1,0 +1,25 @@
+name: Minimal OSS Security Policy
+description: |
+  This filter suite contains rules for implementing minimum
+  security guardrails against risky OSS components.
+tags:
+  - general
+  - vet
+  - oss-maintainers
+filters:
+  - name: critical-or-high-vulns
+    check_type: CheckTypeVulnerability
+    summary: Critical or high risk vulnerabilities were found
+    value: |
+      vulns.critical.exists(p, true) || vulns.high.exists(p, true)
+  - name: low-popularity
+    check_type: CheckTypePopularity
+    summary: Component popularity is low by Github stars count
+    value: |
+      projects.exists(p, (p.type == "GITHUB") && (p.stars < 10))
+  - name: osv-malware
+    check_type: CheckTypeMalware
+    summary: Malicious (malware) component detected
+    value: |
+      vulns.all.exists(v, v.id.startsWith("MAL-"))
+

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -1,0 +1,36 @@
+name: vet OSS Components
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  # Required for actions/checkout@v4
+  contents: read
+
+  # Required for writing pull request comment
+  issues: write
+  pull-requests: write
+
+jobs:
+  vet:
+    name: vet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Run vet
+        id: vet
+        uses: safedep/vet-action@v1
+        with:
+          policy: .github/vet/policy.yml
+        env:
+          # Required for writing pull request comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Why?

This PR integrates [vet](https://github.com/safedep/vet) to automate vetting of OSS packages for security vulnerabilities, malware and other risks. The policy is configured to be minimal, checking only for critical & high risk vulnerabilities, malicious libraries. The policy can be fine tuned / improved based on usage.

## Example

For PRs raised from a branch in *this* repository, `vet` will add a PR comment with vetting results. Example:

<img width="588" alt="example" src="https://github.com/user-attachments/assets/06f83184-2c27-45c5-8893-9fb79cee9cfa">


For PRs raised from forked repositories, GitHub by default offer a read only `GITHUB_TOKEN` to actions. This is a security feature to prevent malicious actions to perform write operations in a repository through forks. When such a PR is raised, `vet` cannot add a PR comment without compromising on security (possible with `pull_request_target` but it has a security cost). Instead, the action will fail on policy violation and the policy violation is visible in the action output.

<img width="941" alt="console" src="https://github.com/user-attachments/assets/618127bc-fcec-4b1d-ae10-c5689332bdaf">

### Our Usage

We use `vet` to vet our own packages.

Example PR vetted by vet:

https://github.com/safedep/vet/pull/239#issuecomment-2331412400

Example policy using which the vetting was done:

https://github.com/safedep/vet/blob/main/.github/vet/policy.yml

## Support

If you need help with fine tuning policy or have any question, please tag @abhisek and I am happy to contribute to your project. `vet` is used by multiple open source projects to prevent risky open source components from being included as dependencies.

