### PR TITLE
Switch to native promise and remove bluebird

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,6 @@
     "comma-style": ["error", "last"],
     "computed-property-spacing": ["error", "never"],
     "eol-last": ["error"],
-    "indent": ["error", 4],
     "key-spacing": [
       "error",
       {"beforeColon": false, "afterColon": true, "mode": "strict"}
@@ -56,7 +55,6 @@
     "one-var": ["error", "never"],
     "semi": ["error", "always"],
     "semi-spacing": ["error", {"before": false}],
-    "space-before-function-paren": ["error", "never"],
     "space-in-parens": ["error", "never"],
     "space-infix-ops": ["error"],
     "space-unary-ops": ["error", {"words": true, "nonwords": false}],
@@ -68,6 +66,8 @@
     "console": true,
     "exports": true,
     "module": true,
+    "process": true,
+    "Promise": true,
     "require": false,
     "TextDecoder": false,
     "Uint8Array": false

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -1,42 +1,190 @@
-var _ = require("underscore");
-var bluebird = require("bluebird/js/release/promise")();
+var _ = require('underscore');
+// Replace bluebird with native Promises
+// var bluebird = require("bluebird/js/release/promise")();
 
+// Use the built-in Promise
+// This avoids the need to check if Promise is available
+// since we're requiring Node.js 12+ in package.json
 exports.defer = defer;
-exports.when = bluebird.resolve;
-exports.resolve = bluebird.resolve;
-exports.all = bluebird.all;
-exports.props = bluebird.props;
-exports.reject = bluebird.reject;
-exports.promisify = bluebird.promisify;
-exports.mapSeries = bluebird.mapSeries;
-exports.attempt = bluebird.attempt;
+exports.when = when;
+exports.resolve = resolve;
+exports.all = all;
+exports.props = props;
+exports.reject = reject;
+exports.promisify = promisify;
+exports.mapSeries = mapSeries;
+exports.attempt = attempt;
+exports.nfcall = nfcall;
 
-exports.nfcall = function(func) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var promisedFunc = bluebird.promisify(func);
-    return promisedFunc.apply(null, args);
-};
+function when(value) {
+	return wrapPromise(Promise.resolve(value));
+}
 
-bluebird.prototype.fail = bluebird.prototype.caught;
+function resolve(value) {
+	return wrapPromise(Promise.resolve(value));
+}
 
-bluebird.prototype.also = function(func) {
-    return this.then(function(value) {
-        var returnValue = _.extend({}, value, func(value));
-        return bluebird.props(returnValue);
-    });
-};
+function all(values) {
+	return wrapPromise(Promise.all(values));
+}
+
+function reject(reason) {
+	return wrapPromise(Promise.reject(reason));
+}
+
+function nfcall(func) {
+	var args = Array.prototype.slice.call(arguments, 1);
+	var promisedFunc = promisify(func);
+	return promisedFunc.apply(null, args);
+}
+
+// Since we can't modify Promise.prototype, we'll wrap promises
+function wrapPromise(promise) {
+	// We need to store the original promise for methods like .done
+	var originalPromise = promise;
+	var wrapped = promise.then(function (value) {
+		// This first .then ensures we have a native promise base
+		// before potentially overriding .then
+		return value;
+	});
+
+	// Override .then to always return a wrapped promise
+	wrapped.then = function (onFulfilled, onRejected) {
+		// Call the original native .then but wrap its result
+		var newPromise = originalPromise.then(onFulfilled, onRejected);
+		return wrapPromise(newPromise);
+	};
+
+	// Add .fail as an alias for .catch for Q compatibility
+	wrapped.fail = function (onRejected) {
+		return wrapPromise(originalPromise.catch(onRejected));
+	};
+
+	// Add .caught which is a Bluebird alias for .catch
+	wrapped.caught = function (onRejected) {
+		return wrapPromise(originalPromise.catch(onRejected));
+	};
+
+	// Add .done() method which is used in Bluebird to terminate the chain
+	// and throw any unhandled errors
+	wrapped.done = function () {
+		// Use the original promise here to avoid infinite recursion with the overridden .then
+		return originalPromise.catch(function (error) {
+			// In the next tick, throw the error
+			process.nextTick(function () {
+				throw error;
+			});
+		});
+	};
+
+	// Add .tap method from Bluebird which runs a function and returns the original value
+	wrapped.tap = function (onFulfilled) {
+		// Use the overridden .then to keep the chain wrapped
+		return wrapped.then(function (value) {
+			return Promise.resolve(onFulfilled(value)).then(function () {
+				return value;
+			});
+		});
+	};
+
+	// Add .also method which is used to add additional properties to the result
+	wrapped.also = function (func) {
+		// Use the overridden .then to keep the chain wrapped
+		return wrapped.then(function (value) {
+			var returnValue = _.extend({}, value, func(value));
+			return props(returnValue);
+		});
+	};
+
+	return wrapped;
+}
 
 function defer() {
-    var resolve;
-    var reject;
-    var promise = new bluebird.Promise(function(resolveArg, rejectArg) {
-        resolve = resolveArg;
-        reject = rejectArg;
-    });
+	var resolve;
+	var reject;
+	var promise = new Promise(function (resolveArg, rejectArg) {
+		resolve = resolveArg;
+		reject = rejectArg;
+	});
 
-    return {
-        resolve: resolve,
-        reject: reject,
-        promise: promise
-    };
+	return {
+		resolve: resolve,
+		reject: reject,
+		promise: wrapPromise(promise)
+	};
+}
+
+// Implement Bluebird's props method using native Promises
+function props(obj) {
+	var keys = Object.keys(obj);
+	var values = keys.map(function (key) {
+		return obj[key];
+	});
+
+	return wrapPromise(
+		Promise.all(values).then(function (results) {
+			var result = {};
+			keys.forEach(function (key, index) {
+				result[key] = results[index];
+			});
+			return result;
+		})
+	);
+}
+
+// Implement Bluebird's promisify
+function promisify(nodeFunction) {
+	return function () {
+		var self = this;
+		var args = Array.prototype.slice.call(arguments);
+
+		return wrapPromise(
+			new Promise(function (resolve, reject) {
+				args.push(function (err, result) {
+					if (err) {
+						reject(err);
+					} else {
+						resolve(result);
+					}
+				});
+
+				nodeFunction.apply(self, args);
+			})
+		);
+	};
+}
+
+// Implement Bluebird's mapSeries
+function mapSeries(items, iterator) {
+	if (!items.length) {
+		return wrapPromise(Promise.resolve([]));
+	}
+
+	var results = [];
+	var current = Promise.resolve();
+
+	items.forEach(function (item) {
+		current = current
+			.then(function () {
+				return iterator(item);
+			})
+			.then(function (result) {
+				results.push(result);
+			});
+	});
+
+	return wrapPromise(
+		current.then(function () {
+			return results;
+		})
+	);
+}
+
+// Implement Bluebird's attempt
+function attempt(fn) {
+	try {
+		return wrapPromise(Promise.resolve(fn()));
+	} catch (error) {
+		return wrapPromise(Promise.reject(error));
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "mammoth",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mammoth",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
         "argparse": "~1.0.3",
         "base64-js": "^1.5.1",
-        "bluebird": "~3.4.0",
         "dingbat-to-unicode": "^1.0.1",
         "jszip": "^3.7.1",
         "lop": "^0.4.2",
@@ -296,7 +295,8 @@
     "node_modules/bluebird": {
       "version": "3.4.7",
       "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.11.6",
@@ -3325,7 +3325,8 @@
     "bluebird": {
       "version": "3.4.7",
       "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@xmldom/xmldom": "^0.8.6",
     "argparse": "~1.0.3",
     "base64-js": "^1.5.1",
-    "bluebird": "~3.4.0",
     "dingbat-to-unicode": "^1.0.1",
     "jszip": "^3.7.1",
     "lop": "^0.4.2",


### PR DESCRIPTION
Switching to native promises and removing bluebird dependency without breaking too much.

Reason:
bluebird have security issue