### PR TITLE
Parse image dimensions

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -183,7 +183,9 @@ function Image(options) {
             });
         },
         altText: options.altText,
-        contentType: options.contentType
+        contentType: options.contentType,
+        height: options.height,
+        width: options.width,
     };
 }
 

--- a/lib/docx/body-reader.js
+++ b/lib/docx/body-reader.js
@@ -525,24 +525,37 @@ function BodyReader(options) {
     }
 
     function readDrawingElement(element) {
-        var blips = element
+        var picture = element
             .getElementsByTagName("a:graphic")
             .getElementsByTagName("a:graphicData")
             .getElementsByTagName("pic:pic")
+        var blips = picture
             .getElementsByTagName("pic:blipFill")
             .getElementsByTagName("a:blip");
+        var dimensions =
+            element.first('wp:extent') ||
+            picture
+                .getElementsByTagName('pic:spPr')
+                .getElementsByTagName('x:xfrm')
+                .attributes['a:ext']
 
-        return combineResults(blips.map(readBlip.bind(null, element)));
+        return combineResults(blips.map((blip) => {
+            return readBlip(element, blip, dimensions)
+        }));
     }
 
-    function readBlip(element, blip) {
+    function readBlip(element, blip, dimensions) {
         var properties = element.first("wp:docPr").attributes;
         var altText = isBlank(properties.descr) ? properties.title : properties.descr;
         var blipImageFile = findBlipImageFile(blip);
         if (blipImageFile === null) {
             return emptyResultWithMessages([warning("Could not find image file for a:blip element")]);
         } else {
-            return readImage(blipImageFile, altText);
+            return readImage(blipImageFile, {
+                altText,
+                height: dimensions.attributes['cy'],
+                width: dimensions.attributes['cx'],
+            });
         }
     }
 
@@ -586,13 +599,15 @@ function BodyReader(options) {
         };
     }
 
-    function readImage(imageFile, altText) {
+    function readImage(imageFile, options) {
         var contentType = contentTypes.findContentType(imageFile.path);
 
         var image = documents.Image({
             readImage: imageFile.read,
-            altText: altText,
-            contentType: contentType
+            altText: options.altText,
+            contentType: contentType,
+            height: options.height,
+            width: options.width
         });
         var warnings = supportedImageTypes[contentType] ?
             [] : warning("Image of type " + contentType + " is unlikely to display in web browsers");


### PR DESCRIPTION
- Closes #187 

## Roadmap

- [ ] Discuss which units to use when exposing the image's `cx` and `cy`? They are in EMU by default. We can convert them to pixels, but we have to be consistent with how Mammoth treats other measurements here. 