### PR TITLE
Fix issues with numering in ordered list

### DIFF
--- a/lib/document-to-html.js
+++ b/lib/document-to-html.js
@@ -30,6 +30,10 @@ function DocumentConversion(options, comments) {
     var noteReferences = [];
 
     var referencedComments = [];
+    
+    var listState = {
+        currentLists: {} // Track current lists by key (numId + level + isOrdered)
+    };
 
     options = _.extend({ignoreEmptyParagraphs: true}, options);
     var idPrefix = options.idPrefix === undefined ? "" : options.idPrefix;
@@ -42,7 +46,7 @@ function DocumentConversion(options, comments) {
     function convertToHtml(document) {
         var messages = [];
 
-        var html = elementToHtml(document, messages, {});
+        var html = elementToHtml(document, messages, {listState: listState});
 
         var deferredNodes = [];
         walkHtml(html, function(node) {
@@ -81,9 +85,91 @@ function DocumentConversion(options, comments) {
     }
 
     function convertElements(elements, messages, options) {
-        return flatMap(elements, function(element) {
-            return elementToHtml(element, messages, options);
-        });
+        var result = [];
+        var lastListKey = null;
+        var lastWasListItem = false;
+        var continuedListStartNumber = null;
+        
+        for (var i = 0; i < elements.length; i++) {
+            var element = elements[i];
+            
+            // Track list state for paragraphs with numbering
+            if (element.type === "paragraph" && element.numbering) {
+                var numbering = element.numbering;
+                var listKey = (numbering.numId || "default") + "_" + numbering.level + "_" + numbering.isOrdered;
+                
+                if (!listState.currentLists[listKey]) {
+                    listState.currentLists[listKey] = {
+                        count: 0
+                    };
+                }
+                
+                // Check if we're continuing a previous list
+                var isListContinuation = false;
+                // Mark as continuation only if:
+                // 1. This is the same list we've seen before (same key)
+                // 2. We weren't just in this list (there was a gap)
+                // 3. This list has items from before
+                if (listKey === lastListKey && lastWasListItem) {
+                    // Same list, consecutive items - use the same start number if in a continued list
+                    isListContinuation = false;
+                } else if (listState.currentLists[listKey].count > 0) {
+                    // Resuming a list after interruption
+                    isListContinuation = true;
+                    continuedListStartNumber = listState.currentLists[listKey].count + 1;
+                } else {
+                    // New list
+                    continuedListStartNumber = null;
+                }
+                
+                // Check if this is a new list (different from previous)
+                // Only force new lists for ordered lists with different numIds
+                var isNewList = false;
+                if (lastListKey !== null && listKey !== lastListKey && lastWasListItem) {
+                    var lastNumId = lastListKey.split("_")[0];
+                    var currentNumId = listKey.split("_")[0];
+                    var lastIsOrdered = lastListKey.split("_")[2] === "true";
+                    
+                    // Force new list only if it's ordered lists with different numIds
+                    isNewList = numbering.isOrdered && lastIsOrdered && lastNumId !== currentNumId;
+                }
+                
+                // Pass list continuation info in options
+                var elementOptions = _.extend({}, options, {
+                    listContinuation: isListContinuation,
+                    listStartNumber: isListContinuation ? continuedListStartNumber : null,
+                    continuedListStartNumber: !isListContinuation && continuedListStartNumber && listKey === lastListKey && lastWasListItem ? continuedListStartNumber : null,
+                    forceNewList: isNewList
+                });
+                
+                // Special case: if this is a consecutive item without startOverride following an item with startOverride,
+                // we need to use the previous item's startOverride to merge them into the same list
+                if (!isListContinuation && !isNewList && !numbering.startOverride &&
+                    listKey === lastListKey && lastWasListItem &&
+                    elements[i - 1] && elements[i - 1].numbering && elements[i - 1].numbering.startOverride) {
+                    elementOptions.continuedListStartNumber = elements[i - 1].numbering.startOverride;
+                }
+                
+                var converted = elementToHtml(element, messages, elementOptions);
+                
+                // Update list count
+                if (numbering.isOrdered) {
+                    listState.currentLists[listKey].count++;
+                }
+                
+                lastListKey = listKey;
+                lastWasListItem = true;
+                
+                result = result.concat(converted);
+            } else {
+                // Not a list element
+                lastWasListItem = false;
+                continuedListStartNumber = null; // Reset when we leave the list
+                result = result.concat(elementToHtml(element, messages, options));
+            }
+        }
+        
+        return result;
     }
 
     function elementToHtml(element, messages, options) {
@@ -99,7 +185,23 @@ function DocumentConversion(options, comments) {
     }
 
     function convertParagraph(element, messages, options) {
-        return htmlPathForParagraph(element, messages).wrap(function() {
+        var htmlPath = htmlPathForParagraph(element, messages);
+        
+        // Check if numbering has startOverride
+        if (element.numbering && element.numbering.isOrdered && element.numbering.startOverride) {
+            htmlPath = modifyHtmlPathForListContinuation(htmlPath, element.numbering.startOverride);
+        } else if (options && options.listContinuation && options.listStartNumber && element.numbering && element.numbering.isOrdered) {
+            // If this is a list continuation after interruption, we need to modify the HTML path
+            htmlPath = modifyHtmlPathForListContinuation(htmlPath, options.listStartNumber);
+        } else if (options && options.continuedListStartNumber && element.numbering && element.numbering.isOrdered) {
+            // For consecutive items in a continued list, add the same start attribute so they merge
+            htmlPath = modifyHtmlPathForListContinuation(htmlPath, options.continuedListStartNumber);
+        } else if (options && options.forceNewList && element.numbering) {
+            // Force a new list by making the ol/ul element fresh
+            htmlPath = makeFreshList(htmlPath);
+        }
+        
+        return htmlPath.wrap(function() {
             var content = convertElements(element.children, messages, options);
             if (ignoreEmptyParagraphs) {
                 return content;
@@ -349,6 +451,47 @@ function DocumentConversion(options, comments) {
         } else {
             return htmlPaths.empty;
         }
+    }
+    
+    function modifyHtmlPathForListContinuation(htmlPath, startNumber) {
+        // We need to intercept the HTML path elements and add start attribute to ol elements
+        if (htmlPath._elements) {
+            var modifiedElements = htmlPath._elements.map(function(element) {
+                if (element.tagName === "ol" || (element.tagNames && element.tagNames.ol)) {
+                    // Create a new element with start attribute
+                    return _.extend({}, element, {
+                        attributes: _.extend({}, element.attributes, {
+                            start: startNumber.toString()
+                        })
+                    });
+                }
+                return element;
+            });
+            
+            return htmlPaths.elements(modifiedElements);
+        }
+        
+        return htmlPath;
+    }
+    
+    function makeFreshList(htmlPath) {
+        // Make the list element (ol/ul) fresh to prevent merging with previous lists
+        if (htmlPath._elements) {
+            var modifiedElements = htmlPath._elements.map(function(element) {
+                if (element.tagName === "ol" || element.tagName === "ul" ||
+                    (element.tagNames && (element.tagNames.ol || element.tagNames.ul))) {
+                    // Create a new element that's fresh
+                    return _.extend({}, element, {
+                        fresh: true
+                    });
+                }
+                return element;
+            });
+            
+            return htmlPaths.elements(modifiedElements);
+        }
+        
+        return htmlPath;
     }
 
     var elementConverters = {

--- a/lib/docx/numbering-xml.js
+++ b/lib/docx/numbering-xml.js
@@ -23,10 +23,20 @@ function Numbering(nums, abstractNums, styles) {
             if (!abstractNum) {
                 return null;
             } else if (abstractNum.numStyleLink == null) {
-                return abstractNums[num.abstractNumId].levels[level];
+                var baseLevel = abstractNums[num.abstractNumId].levels[level];
+                if (baseLevel && num.levelOverrides && num.levelOverrides[level]) {
+                    return _.extend({}, baseLevel, num.levelOverrides[level]);
+                }
+                return baseLevel;
             } else {
+                // When there's a numStyleLink, we need to get the level from the linked style
+                // but still apply any levelOverrides from the original num
                 var style = styles.findNumberingStyleById(abstractNum.numStyleLink);
-                return findLevel(style.numId, level);
+                var styledLevel = findLevel(style.numId, level);
+                if (styledLevel && num.levelOverrides && num.levelOverrides[level]) {
+                    return _.extend({}, styledLevel, num.levelOverrides[level]);
+                }
+                return styledLevel;
             }
         } else {
             return null;
@@ -86,7 +96,22 @@ function readNums(root) {
     root.getElementsByTagName("w:num").forEach(function(element) {
         var numId = element.attributes["w:numId"];
         var abstractNumId = element.first("w:abstractNumId").attributes["w:val"];
-        nums[numId] = {abstractNumId: abstractNumId};
+        
+        var levelOverrides = {};
+        element.getElementsByTagName("w:lvlOverride").forEach(function(overrideElement) {
+            var level = overrideElement.attributes["w:ilvl"];
+            var startOverrideElement = overrideElement.firstOrEmpty("w:startOverride");
+            if (startOverrideElement.attributes["w:val"]) {
+                levelOverrides[level] = {
+                    startOverride: parseInt(startOverrideElement.attributes["w:val"], 10)
+                };
+            }
+        });
+        
+        nums[numId] = {
+            abstractNumId: abstractNumId,
+            levelOverrides: Object.keys(levelOverrides).length > 0 ? levelOverrides : undefined
+        };
     });
     return nums;
 }

--- a/test/docx/numbering-xml.tests.js
+++ b/test/docx/numbering-xml.tests.js
@@ -118,3 +118,80 @@ test('when styles is missing then error is thrown', function() {
         readNumberingXml(new XmlElement("w:numbering", {}, []));
     }, /styles is missing/);
 });
+
+test('w:startOverride in w:lvlOverride overrides start value', function() {
+    var numbering = readNumberingXml(
+        new XmlElement("w:numbering", {}, [
+            new XmlElement("w:abstractNum", {"w:abstractNumId": "42"}, [
+                new XmlElement("w:lvl", {"w:ilvl": "0"}, [
+                    new XmlElement("w:numFmt", {"w:val": "decimal"})
+                ])
+            ]),
+            new XmlElement("w:num", {"w:numId": "47"}, [
+                new XmlElement("w:abstractNumId", {"w:val": "42"}),
+                new XmlElement("w:lvlOverride", {"w:ilvl": "0"}, [
+                    new XmlElement("w:startOverride", {"w:val": "5"})
+                ])
+            ])
+        ]),
+        {styles: stylesReader.defaultStyles}
+    );
+    duck.assertThat(numbering.findLevel("47", "0"), duck.hasProperties({
+        isOrdered: true,
+        startOverride: 5
+    }));
+});
+
+test('levels without startOverride do not have the property', function() {
+    var numbering = readNumberingXml(
+        new XmlElement("w:numbering", {}, [
+            new XmlElement("w:abstractNum", {"w:abstractNumId": "42"}, [
+                new XmlElement("w:lvl", {"w:ilvl": "0"}, [
+                    new XmlElement("w:numFmt", {"w:val": "decimal"})
+                ])
+            ]),
+            new XmlElement("w:num", {"w:numId": "47"}, [
+                new XmlElement("w:abstractNumId", {"w:val": "42"})
+            ])
+        ]),
+        {styles: stylesReader.defaultStyles}
+    );
+    var level = numbering.findLevel("47", "0");
+    duck.assertThat(level, duck.hasProperties({
+        isOrdered: true
+    }));
+    assert.equal(level.startOverride, undefined);
+});
+
+test('multiple levels can have different startOverride values', function() {
+    var numbering = readNumberingXml(
+        new XmlElement("w:numbering", {}, [
+            new XmlElement("w:abstractNum", {"w:abstractNumId": "42"}, [
+                new XmlElement("w:lvl", {"w:ilvl": "0"}, [
+                    new XmlElement("w:numFmt", {"w:val": "decimal"})
+                ]),
+                new XmlElement("w:lvl", {"w:ilvl": "1"}, [
+                    new XmlElement("w:numFmt", {"w:val": "decimal"})
+                ])
+            ]),
+            new XmlElement("w:num", {"w:numId": "47"}, [
+                new XmlElement("w:abstractNumId", {"w:val": "42"}),
+                new XmlElement("w:lvlOverride", {"w:ilvl": "0"}, [
+                    new XmlElement("w:startOverride", {"w:val": "10"})
+                ]),
+                new XmlElement("w:lvlOverride", {"w:ilvl": "1"}, [
+                    new XmlElement("w:startOverride", {"w:val": "20"})
+                ])
+            ])
+        ]),
+        {styles: stylesReader.defaultStyles}
+    );
+    duck.assertThat(numbering.findLevel("47", "0"), duck.hasProperties({
+        isOrdered: true,
+        startOverride: 10
+    }));
+    duck.assertThat(numbering.findLevel("47", "1"), duck.hasProperties({
+        isOrdered: true,
+        startOverride: 20
+    }));
+});


### PR DESCRIPTION
This PR adjusts the ordered list parsing to correctly allow for interruptions in the list.
E.g:
```
1. Lorum
2. Ipsum
* Dolor
3. Sit Amet
```

Will now convert as expected instead of the numbering restarting at 1 after the unordered list.

This also adds the ability to use `w:startOverride` if present, so Documents can correctly alter the starting index of a list.

Closes #413 

