### PR TITLE
fix: missing `type` and `altText` from `Image` interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -42,6 +42,8 @@ interface ImageConverter {
 }
 
 interface Image {
+    type: 'image';
+    altText?: string;
     contentType: string;
     readAsArrayBuffer: () => Promise<ArrayBuffer>;
     readAsBase64String: () => Promise<string>;


### PR DESCRIPTION
Comparing the output of an image of type `Image` to the interface `Image`, `type` and `altText` are missing:

output:
```typescript
image: {
    type: 'image',
    read: [Function: read],
    readAsArrayBuffer: [Function: readAsArrayBuffer],
    readAsBase64String: [Function: readAsBase64String],
    readAsBuffer: [Function: readAsBuffer],
    altText: '6,297,900+ Photo Image Art Stock Photos, Pictures & Royalty-Free Images -  iStock',
    contentType: 'image/jpeg'
  }
```

I've added those 2 types to the `index.d.ts`
