### PR TITLE
Handle cyclic w references

### DIFF
--- a/lib/docx/numbering-xml.js
+++ b/lib/docx/numbering-xml.js
@@ -17,6 +17,19 @@ function Numbering(nums, abstractNums, styles) {
     );
 
     function findLevel(numId, level) {
+        return findLevelInner(numId, level, {});
+    }
+
+    function findLevelInner(numId, level, visited) {
+        // A w:numStyleLink can point (directly or transitively) back to a
+        // numbering definition already visited, forming a cycle. Track the
+        // num IDs seen while resolving this chain so a malformed document
+        // cannot cause unbounded recursion.
+        if (visited[numId]) {
+            return null;
+        }
+        visited[numId] = true;
+
         var num = nums[numId];
         if (num) {
             var abstractNum = abstractNums[num.abstractNumId];
@@ -26,7 +39,7 @@ function Numbering(nums, abstractNums, styles) {
                 return abstractNums[num.abstractNumId].levels[level];
             } else {
                 var style = styles.findNumberingStyleById(abstractNum.numStyleLink);
-                return findLevel(style.numId, level);
+                return findLevelInner(style.numId, level, visited);
             }
         } else {
             return null;

--- a/test/docx/numbering-xml.tests.js
+++ b/test/docx/numbering-xml.tests.js
@@ -152,6 +152,25 @@ test('when w:abstractNum has w:numStyleLink then style is used to find w:num', f
 });
 
 
+test('findLevel returns null when w:numStyleLink forms a cycle', function() {
+    // num 201 -> abstractNum 101 -> numStyleLink "List1" -> num 201 -> ...
+    // Without cycle detection this recurses until the call stack is exhausted;
+    // findLevel should instead return null.
+    var numbering = readNumberingXml(
+        new XmlElement("w:numbering", {}, [
+            new XmlElement("w:abstractNum", {"w:abstractNumId": "101"}, [
+                new XmlElement("w:numStyleLink", {"w:val": "List1"})
+            ]),
+            new XmlElement("w:num", {"w:numId": "201"}, [
+                new XmlElement("w:abstractNumId", {"w:val": "101"})
+            ])
+        ]),
+        {styles: new stylesReader.Styles({}, {}, {}, {"List1": {numId: "201"}})}
+    );
+    duck.assertThat(numbering.findLevel("201", "0"), duck.equalTo(null));
+});
+
+
 // See: 17.9.23 pStyle (Paragraph Style's Associated Numbering Level) in ECMA-376, 4th Edition
 test('numbering level can be found by paragraph style ID', function() {
     var numbering = readNumberingXml(


### PR DESCRIPTION
findLevel resolves w:numStyleLink by following the referenced numbering style to another w:num. If those references form a cycle, the lookup currently recurses until Node raises RangeError: Maximum call stack size exceeded.

This change tracks num IDs visited during a single lookup and returns null when a num ID is seen twice. A cyclic chain is therefore treated as having no resolvable level.

No behaviour change for valid documents; existing numbering tests pass unchanged.

Adds one regression test covering a two-entry w:numStyleLink cycle.
